### PR TITLE
feat: capture and forward policy_snapshot for proxy OPA enforcement

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -304,6 +304,7 @@ export class ArmorIQClient {
         totalSteps: planCapture.plan.steps?.length || 0,
         rawToken,
         jwtToken: data.jwt_token,
+        policySnapshot: data.policy_snapshot,
       };
 
       console.log(
@@ -376,6 +377,7 @@ export class ArmorIQClient {
       plan: intentToken.rawToken?.plan,
       _iam_context: iamContext,
       ...(userEmail ? { user_email: userEmail } : {}),
+      ...(intentToken.policySnapshot ? { policy_snapshot: intentToken.policySnapshot } : {}),
     };
 
     // Prepare headers

--- a/src/models.ts
+++ b/src/models.ts
@@ -34,6 +34,8 @@ export interface IntentToken {
   rawToken: Record<string, any>;
   /** JWT token for verify-step endpoint */
   jwtToken?: string;
+  /** OPA-formatted policy snapshot for proxy → OPA direct enforcement */
+  policySnapshot?: Array<Record<string, any>>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `policySnapshot` field to `IntentToken` interface
- Capture `policy_snapshot` from backend `/iap/sdk/token` response
- Forward `policy_snapshot` in `invoke()` payload to proxy
- Enables proxy → OPA direct enforcement without independent policy fetch

## Why
The proxy needs OPA-formatted policy data to call OPA directly for obligation enforcement (amountThreshold, velocityLimit). Previously the proxy had to independently fetch policies from the backend — now the SDK carries the data from token issuance.

## Backward compatible
- Old proxies ignore the extra `policy_snapshot` field
- Old backends without `policy_snapshot` return `undefined` — SDK handles gracefully

## Test plan
- [x] `getIntentToken()` captures `policy_snapshot` from backend response
- [x] `invoke()` includes `policy_snapshot` in proxy payload
- [x] Proxy reads `policy_snapshot` and calls OPA directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)