### PR TITLE
Release v0.2.11: update prod URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,9 @@ CONTEXT_ID=default
 ARMORIQ_ENV=development
 
 # Optional: Override service endpoints
-# IAP_ENDPOINT=https://customer-iap.armoriq.ai
-# PROXY_ENDPOINT=https://customer-proxy.armoriq.ai
-# BACKEND_ENDPOINT=https://customer-api.armoriq.ai
+# IAP_ENDPOINT=https://iap.armoriq.ai
+# PROXY_ENDPOINT=https://proxy.armoriq.ai
+# BACKEND_ENDPOINT=https://api.armoriq.ai
 
 # Optional: MCP-specific proxy endpoints
 # WEATHER_MCP_PROXY_URL=https://weather-proxy.example.com

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ AGENT_ID=your-agent-id
 # Optional
 ARMORIQ_ENV=production  # or 'development' for local
 CONTEXT_ID=default
-IAP_ENDPOINT=https://customer-iap.armoriq.ai
-PROXY_ENDPOINT=https://customer-proxy.armoriq.ai
-BACKEND_ENDPOINT=https://customer-api.armoriq.ai
+IAP_ENDPOINT=https://iap.armoriq.ai
+PROXY_ENDPOINT=https://proxy.armoriq.ai
+BACKEND_ENDPOINT=https://api.armoriq.ai
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.2.9",
+  "version": "0.2.11",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,7 +31,7 @@ import {
 
 /**
  * Main client for ArmorIQ SDK.
- * 
+ *
  * Provides high-level APIs for:
  * - Plan capture and canonicalization
  * - Intent token management
@@ -40,9 +40,9 @@ import {
  */
 export class ArmorIQClient {
   // Production endpoints (default) - ArmorIQ platform
-  private static readonly DEFAULT_IAP_ENDPOINT = 'https://customer-iap.armoriq.ai';
-  private static readonly DEFAULT_PROXY_ENDPOINT = 'https://customer-proxy.armoriq.ai';
-  private static readonly DEFAULT_BACKEND_ENDPOINT = 'https://customer-api.armoriq.ai';
+  private static readonly DEFAULT_IAP_ENDPOINT = 'https://iap.armoriq.ai';
+  private static readonly DEFAULT_PROXY_ENDPOINT = 'https://proxy.armoriq.ai';
+  private static readonly DEFAULT_BACKEND_ENDPOINT = 'https://api.armoriq.ai';
 
   // ArmorClaw standalone product endpoints
   private static readonly ARMORCLAW_IAP_ENDPOINT = 'https://iap.armorclaw.io';


### PR DESCRIPTION
## Summary
- Merge dev into main: updates prod endpoints to `iap.armoriq.ai`, `proxy.armoriq.ai`, `api.armoriq.ai` (from `customer-*` prefixed URLs)
- Bump version to 0.2.11
- Already published to npm as `@armoriq/sdk@0.2.11`

## Test plan
- [ ] Install `@armoriq/sdk@0.2.11` and verify prod endpoints resolve correctly