### PR TITLE
feat(sdk): agent-managed MCP creds + ArmorIQSession + framework integrations (v0.2.12)

### DIFF
--- a/examples/adk-stripe-agent.ts
+++ b/examples/adk-stripe-agent.ts
@@ -1,0 +1,50 @@
+/**
+ * ArmorIQ + Google ADK — Stripe agent example.
+ *
+ * Mirrors the "After" snippet in ARMORIQ_INTEGRATION.md:
+ *  - 8 lines changed vs. a plain ADK + Stripe MCP agent
+ *  - Agent never holds the upstream Stripe key directly; Armoriq
+ *    forwards it from the per-agent env (or the platform-stored cred
+ *    if onboarded that way).
+ *
+ * Run:
+ *   ARMORIQ_API_KEY=ak_live_... \
+ *   ARMORIQ_PROXY_URL=http://localhost:3001 \
+ *   GOOGLE_API_KEY=... \
+ *   ARMORIQ_MCP_STRIPE_AUTH_TYPE=bearer \
+ *   ARMORIQ_MCP_STRIPE_TOKEN=sk_test_... \
+ *   npx tsx examples/adk-stripe-agent.ts "list customers"
+ */
+
+import 'dotenv/config';
+// @ts-ignore — @google/adk is an optional peer dep; consumers install it.
+import { LlmAgent, MCPToolset, Runner } from '@google/adk';
+import { ArmorIQADK } from '../src/integrations/google-adk';
+
+const PROXY_URL = process.env.ARMORIQ_PROXY_URL || 'http://localhost:3001';
+const API_KEY = process.env.ARMORIQ_API_KEY!;
+const MCP_NAME = process.env.MCP_NAME || 'Stripe';
+
+const armoriq = new ArmorIQADK({ apiKey: API_KEY, proxyUrl: PROXY_URL });
+
+export const rootAgent = new LlmAgent({
+  model: 'gemini-2.5-flash',
+  name: `${MCP_NAME.toLowerCase()}_agent`,
+  description: `An agent that interacts with ${MCP_NAME}.`,
+  instruction: `You are a helpful ${MCP_NAME} assistant. Use the available tools.`,
+  plugins: [armoriq],
+  tools: [
+    new MCPToolset({
+      type: 'StreamableHTTPConnectionParams',
+      url: `${PROXY_URL}/mcp/${MCP_NAME}`,
+      transportOptions: {
+        requestInit: { headers: { 'X-API-Key': API_KEY } },
+      },
+    }),
+  ],
+});
+
+if (require.main === module) {
+  const prompt = process.argv.slice(2).join(' ') || 'List my recent customers';
+  Runner.runSync(rootAgent, prompt).then((r: unknown) => console.log(r));
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,39 @@
 {
-  "name": "@armoriq/sdk",
-  "version": "0.2.9",
+  "name": "@armoriq/sdk-dev",
+  "version": "0.2.12",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./integrations": {
+      "types": "./dist/integrations/index.d.ts",
+      "default": "./dist/integrations/index.js"
+    },
+    "./integrations/google-adk": {
+      "types": "./dist/integrations/google-adk.d.ts",
+      "default": "./dist/integrations/google-adk.js"
+    },
+    "./integrations/crewai": {
+      "types": "./dist/integrations/crewai.d.ts",
+      "default": "./dist/integrations/crewai.js"
+    },
+    "./integrations/langchain": {
+      "types": "./dist/integrations/langchain.d.ts",
+      "default": "./dist/integrations/langchain.js"
+    },
+    "./integrations/openai": {
+      "types": "./dist/integrations/openai.d.ts",
+      "default": "./dist/integrations/openai.js"
+    },
+    "./integrations/anthropic": {
+      "types": "./dist/integrations/anthropic.d.ts",
+      "default": "./dist/integrations/anthropic.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -39,6 +69,20 @@
   ],
   "dependencies": {
     "axios": "^1.7.0"
+  },
+  "peerDependencies": {
+    "@google/adk": "^0.6.1",
+    "@langchain/core": "^0.3.0",
+    "openai": "^4.0.0",
+    "@anthropic-ai/sdk": "^0.27.0",
+    "crewai": "*"
+  },
+  "peerDependenciesMeta": {
+    "@google/adk": { "optional": true },
+    "@langchain/core": { "optional": true },
+    "openai": { "optional": true },
+    "@anthropic-ai/sdk": { "optional": true },
+    "crewai": { "optional": true }
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,6 +17,8 @@ import {
   DelegationRequestResult,
   ApprovedDelegation,
   HoldInfo,
+  McpCredential,
+  McpCredentialMap,
 } from './models';
 import {
   InvalidTokenException,
@@ -40,9 +42,9 @@ import {
  */
 export class ArmorIQClient {
   // Production endpoints (default) - ArmorIQ platform
-  private static readonly DEFAULT_IAP_ENDPOINT = 'https://iap.armoriq.ai';
-  private static readonly DEFAULT_PROXY_ENDPOINT = 'https://proxy.armoriq.ai';
-  private static readonly DEFAULT_BACKEND_ENDPOINT = 'https://api.armoriq.ai';
+  private static readonly DEFAULT_IAP_ENDPOINT = 'https://iap.armoriq.io';
+  private static readonly DEFAULT_PROXY_ENDPOINT = 'https://cloud-run-proxy.armoriq.io';
+  private static readonly DEFAULT_BACKEND_ENDPOINT = 'https://staging-api.armoriq.io';
 
   // ArmorClaw standalone product endpoints
   private static readonly ARMORCLAW_IAP_ENDPOINT = 'https://iap.armorclaw.io';
@@ -73,6 +75,7 @@ export class ArmorIQClient {
   private httpClient: AxiosInstance;
   private tokenCache: Map<string, IntentToken>;
   private metadataCache: Map<string, MCPSemanticMetadata>;
+  private mcpCredentials: McpCredentialMap;
 
   constructor(options: Partial<SDKConfig> & { apiKey?: string; useProduction?: boolean } = {}) {
     // Determine if using production based on environment
@@ -143,7 +146,7 @@ export class ArmorIQClient {
 
     // Initialize HTTP client
     const headers: Record<string, string> = {
-      'User-Agent': `ArmorIQ-SDK-TS/0.2.6 (agent=${this.agentId})`,
+      'User-Agent': `ArmorIQ-SDK-TS/0.2.12 (agent=${this.agentId})`,
     };
     if (this.apiKey) {
       headers['Authorization'] = `Bearer ${this.apiKey}`;
@@ -157,6 +160,7 @@ export class ArmorIQClient {
 
     this.tokenCache = new Map();
     this.metadataCache = new Map();
+    this.mcpCredentials = ArmorIQClient.resolveMcpCredentials(options.mcpCredentials);
 
     console.log(
       `ArmorIQ SDK initialized: mode=${useProd ? 'production' : 'development'}, ` +
@@ -175,6 +179,103 @@ export class ArmorIQClient {
    */
   get proxyEndpoint(): string {
     return this.defaultProxyEndpoint;
+  }
+
+  /**
+   * Open a new session for one LLM turn / one plan. Use this with a
+   * framework integration (ADK, LangChain, etc.) to compress the
+   * capture-plan / mint-token / invoke-tool dance into two calls.
+   */
+  startSession(opts?: import('./session').SessionOptions): import('./session').ArmorIQSession {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const sessionMod = require('./session') as typeof import('./session');
+    return new sessionMod.ArmorIQSession(this, opts);
+  }
+
+  /**
+   * Resolve per-MCP credentials from env + constructor option.
+   *
+   * Precedence (later wins):
+   *   1. ARMORIQ_MCP_CREDENTIALS (JSON blob)
+   *   2. ARMORIQ_MCP_<SAFE_NAME>_* per-MCP env vars
+   *   3. constructor option `mcpCredentials`
+   *
+   * SAFE_NAME = mcpName.toUpperCase().replace(/[^A-Z0-9]/g, '_')
+   */
+  private static resolveMcpCredentials(fromOptions?: McpCredentialMap): McpCredentialMap {
+    const merged: McpCredentialMap = {};
+
+    // 1. JSON blob
+    const jsonRaw = process.env.ARMORIQ_MCP_CREDENTIALS;
+    if (jsonRaw) {
+      try {
+        const parsed = JSON.parse(jsonRaw);
+        if (parsed && typeof parsed === 'object') {
+          for (const [k, v] of Object.entries(parsed)) {
+            merged[k] = v as McpCredential;
+          }
+        }
+      } catch (e: any) {
+        console.warn(`Failed to parse ARMORIQ_MCP_CREDENTIALS as JSON: ${e?.message ?? e}`);
+      }
+    }
+
+    // 2. Per-MCP env vars
+    const safeNames = new Set<string>();
+    for (const key of Object.keys(process.env)) {
+      const m = key.match(/^ARMORIQ_MCP_(.+)_AUTH_TYPE$/);
+      if (m) safeNames.add(m[1]);
+    }
+    for (const safeName of safeNames) {
+      const authType = (process.env[`ARMORIQ_MCP_${safeName}_AUTH_TYPE`] || '').toLowerCase();
+      let cred: McpCredential | null = null;
+      if (authType === 'bearer') {
+        const token = process.env[`ARMORIQ_MCP_${safeName}_TOKEN`];
+        if (token) cred = { authType: 'bearer', token };
+      } else if (authType === 'api_key') {
+        const apiKey = process.env[`ARMORIQ_MCP_${safeName}_API_KEY`];
+        const headerName = process.env[`ARMORIQ_MCP_${safeName}_HEADER_NAME`];
+        if (apiKey) cred = { authType: 'api_key', apiKey, headerName };
+      } else if (authType === 'basic') {
+        const username = process.env[`ARMORIQ_MCP_${safeName}_USERNAME`];
+        const password = process.env[`ARMORIQ_MCP_${safeName}_PASSWORD`];
+        if (username && password) cred = { authType: 'basic', username, password };
+      } else if (authType === 'none') {
+        cred = { authType: 'none' };
+      }
+      if (cred) {
+        merged[safeName] = cred;
+      }
+    }
+
+    // 3. Constructor option (highest precedence)
+    if (fromOptions) {
+      for (const [k, v] of Object.entries(fromOptions)) {
+        merged[k] = v;
+      }
+    }
+
+    return merged;
+  }
+
+  /**
+   * Look up the runtime cred for a given MCP name.
+   * Tries the canonical name first, then the safe-name encoding so env-var
+   * users don't have to match the platform's exact casing/punctuation.
+   */
+  private getMcpCredential(mcpName: string): McpCredential | undefined {
+    if (this.mcpCredentials[mcpName]) return this.mcpCredentials[mcpName];
+    const safeName = mcpName.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+    return this.mcpCredentials[safeName];
+  }
+
+  /**
+   * Encode an MCP credential as the X-Armoriq-MCP-Auth header value.
+   * Base64 wrapping avoids header-character issues; not encryption — TLS
+   * handles confidentiality.
+   */
+  private encodeMcpAuthHeader(cred: McpCredential): string {
+    return Buffer.from(JSON.stringify(cred), 'utf8').toString('base64');
   }
 
   /**
@@ -426,6 +527,14 @@ export class ArmorIQClient {
 
     if (this.apiKey) {
       headers['X-API-Key'] = this.apiKey;
+    }
+
+    // Agent-managed upstream MCP cred (default path).
+    // Proxy parses, injects upstream auth header, and drops this one
+    // before forwarding. Armoriq does not store this value.
+    const mcpCred = this.getMcpCredential(mcp);
+    if (mcpCred) {
+      headers['X-Armoriq-MCP-Auth'] = this.encodeMcpAuthHeader(mcpCred);
     }
 
     // Send CSRG token structure

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 export { ArmorIQClient } from './client';
-export { ArmorIQSession, SessionOptions } from './session';
+export { ArmorIQSession, SessionOptions, EnforceResult, ReportOptions } from './session';
 export {
   buildPlanFromToolCalls,
   defaultToolNameParser,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,23 @@
 /**
  * ArmorIQ SDK - Build Secure AI Agents
- * 
+ *
  * A TypeScript SDK for building AI agents with cryptographic intent verification.
  * Provides simple APIs for plan capture, token management, and secure MCP
  * tool invocation with built-in security.
- * 
+ *
  * @author ArmorIQ Team <license@armoriq.io>
- * @version 0.2.6
+ * @version 0.2.12
  */
 
 export { ArmorIQClient } from './client';
+export { ArmorIQSession, SessionOptions } from './session';
+export {
+  buildPlanFromToolCalls,
+  defaultToolNameParser,
+  hashToolCalls,
+  ToolNameParser,
+  BuildPlanOptions,
+} from './plan-builder';
 export {
   ArmorIQException,
   InvalidTokenException,
@@ -37,8 +45,11 @@ export {
   DelegationRequestParams,
   DelegationRequestResult,
   ApprovedDelegation,
+  ToolCall,
+  McpCredential,
+  McpCredentialMap,
 } from './models';
 
-export const VERSION = '0.2.6';
+export const VERSION = '0.2.12';
 export const AUTHOR = 'ArmorIQ Team';
 export const EMAIL = 'license@armoriq.io';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 export { ArmorIQClient } from './client';
-export { ArmorIQSession, SessionOptions, EnforceResult, ReportOptions } from './session';
+export { ArmorIQSession, SessionOptions, SessionMode, EnforceResult, ReportOptions } from './session';
 export {
   buildPlanFromToolCalls,
   defaultToolNameParser,

--- a/src/integrations/anthropic.ts
+++ b/src/integrations/anthropic.ts
@@ -1,0 +1,31 @@
+/**
+ * ArmorIQ — Anthropic integration. (Coming Soon)
+ *
+ * Mirrors the Python SDK's ArmorIQAnthropic stub. When implemented,
+ * this will inspect tool_use blocks in Anthropic SDK responses and
+ * route each through the Armoriq proxy via ArmorIQSession.
+ *
+ * Requires: `npm install @anthropic-ai/sdk`
+ */
+
+import { ArmorIQClient } from '../client';
+
+export interface ArmorIQAnthropicOptions {
+  armoriqClient: ArmorIQClient;
+  [key: string]: any;
+}
+
+export class ArmorIQAnthropic {
+  constructor(_options: ArmorIQAnthropicOptions) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('@anthropic-ai/sdk');
+    } catch {
+      throw new Error(
+        '@anthropic-ai/sdk is not installed.\n' +
+          'Install it with: npm install @anthropic-ai/sdk',
+      );
+    }
+    throw new Error('ArmorIQ Anthropic integration is not yet implemented.');
+  }
+}

--- a/src/integrations/crewai.ts
+++ b/src/integrations/crewai.ts
@@ -1,0 +1,223 @@
+/**
+ * ArmorIQ — CrewAI integration.
+ *
+ * Port of armoriq_sdk.integrations.crewai (Python). CrewAI is
+ * primarily a Python framework; this TS integration works against the
+ * experimental `@crewaijs/crewai` npm port.
+ *
+ * Pattern (same as Python):
+ *   1. Collect every tool from the crew's agents that exposes `.mcp`
+ *      and `.action` properties (these are the Armoriq-bound tools).
+ *   2. Build a plan and mint an intent token via ArmorIQSession.
+ *   3. Patch each tool's `_run` (or `invoke`) to route through the
+ *      Armoriq proxy via `session.dispatch`.
+ *   4. Restore the originals after kickoff.
+ *
+ * Usage:
+ *
+ *   import { ArmorIQCrew } from '@armoriq/sdk-dev/integrations/crewai';
+ *
+ *   const crew = new ArmorIQCrew({
+ *     agents: [...], tasks: [...],
+ *     armoriqClient: client,
+ *     llm: 'gpt-4o',
+ *   });
+ *   const result = await crew.kickoff();
+ *
+ * If `crewai` (the JS port) is not installed, instantiation throws
+ * with install instructions — matching the Python behavior.
+ */
+
+import { ArmorIQClient } from '../client';
+import { ArmorIQSession } from '../session';
+import { ToolCall } from '../models';
+
+export interface CrewLikeAgent {
+  tools?: Array<CrewLikeTool>;
+}
+
+export interface CrewLikeTool {
+  mcp?: string;
+  action?: string;
+  _run?: (...args: any[]) => any;
+  invoke?: (...args: any[]) => any;
+  name?: string;
+}
+
+export interface CrewLikeTask {
+  description?: string;
+  expected_output?: string;
+}
+
+export interface ArmorIQCrewOptions {
+  agents: CrewLikeAgent[];
+  tasks: CrewLikeTask[];
+  /** Any other fields forwarded to the CrewAI Crew constructor. */
+  [key: string]: any;
+
+  armoriqClient: ArmorIQClient;
+  llm?: string;
+  tokenValiditySeconds?: number;
+}
+
+function tryRequireCrewai(): any {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('crewai');
+  } catch {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      return require('@crewaijs/crewai');
+    } catch (err: any) {
+      throw new Error(
+        'crewai is not installed.\n' +
+          'Install a CrewAI JS port: npm install crewai  (or @crewaijs/crewai).\n' +
+          `Underlying error: ${err?.message ?? err}`,
+      );
+    }
+  }
+}
+
+function collectArmoriqTools(agents: CrewLikeAgent[]): CrewLikeTool[] {
+  const seen = new Set<any>();
+  const tools: CrewLikeTool[] = [];
+  for (const agent of agents) {
+    for (const tool of agent?.tools ?? []) {
+      if (tool && typeof tool.mcp === 'string' && typeof tool.action === 'string') {
+        if (!seen.has(tool)) {
+          seen.add(tool);
+          tools.push(tool);
+        }
+      }
+    }
+  }
+  return tools;
+}
+
+function buildToolCalls(tools: CrewLikeTool[]): ToolCall[] {
+  const seen = new Set<string>();
+  const out: ToolCall[] = [];
+  for (const t of tools) {
+    const key = `${t.mcp}__${t.action}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push({ name: key, args: {} });
+    }
+  }
+  return out;
+}
+
+function deriveGoal(tasks: CrewLikeTask[]): string {
+  const parts: string[] = [];
+  for (const t of tasks) {
+    const d = t.description ?? t.expected_output;
+    if (d) parts.push(d);
+  }
+  return parts.length ? parts.join(' ') : 'Execute crew tasks';
+}
+
+export class ArmorIQCrew {
+  private crew: any;
+  private armoriqClient: ArmorIQClient;
+  private llm: string;
+  private validitySeconds: number;
+  private agents: CrewLikeAgent[];
+  private tasks: CrewLikeTask[];
+  private session: ArmorIQSession | null = null;
+
+  constructor(options: ArmorIQCrewOptions) {
+    const crewai = tryRequireCrewai();
+    const Crew = crewai.Crew ?? crewai.default?.Crew;
+    if (!Crew) {
+      throw new Error(
+        'The installed crewai package does not export a Crew class.',
+      );
+    }
+
+    const {
+      armoriqClient,
+      llm,
+      tokenValiditySeconds,
+      agents,
+      tasks,
+      ...rest
+    } = options;
+
+    this.armoriqClient = armoriqClient;
+    this.llm = llm ?? 'agent';
+    this.validitySeconds = tokenValiditySeconds ?? 3600;
+    this.agents = agents;
+    this.tasks = tasks;
+    this.crew = new Crew({ agents, tasks, ...rest });
+  }
+
+  private async issueToken(): Promise<ArmorIQSession | null> {
+    const tools = collectArmoriqTools(this.agents);
+    if (tools.length === 0) {
+      // eslint-disable-next-line no-console
+      console.warn('[ArmorIQCrew] No ArmorIQ tools found; crew runs without ArmorIQ verification.');
+      return null;
+    }
+    const toolCalls = buildToolCalls(tools);
+    const session = this.armoriqClient.startSession({
+      llm: this.llm,
+      validitySeconds: this.validitySeconds,
+    });
+    await session.startPlan(toolCalls, { goal: deriveGoal(this.tasks) });
+    return session;
+  }
+
+  private patchTools(session: ArmorIQSession): Array<() => void> {
+    const restorers: Array<() => void> = [];
+    const patched = new Set<CrewLikeTool>();
+    for (const agent of this.agents) {
+      for (const tool of agent?.tools ?? []) {
+        if (
+          !patched.has(tool) &&
+          typeof tool.mcp === 'string' &&
+          typeof tool.action === 'string'
+        ) {
+          patched.add(tool);
+          const original = tool._run ?? tool.invoke;
+          const method: 'invoke' | '_run' = tool.invoke ? 'invoke' : '_run';
+          // Use a typed route through Armoriq.
+          const wrapped = async (...args: any[]) => {
+            const params = (args[0] && typeof args[0] === 'object') ? args[0] : {};
+            const result = await session.dispatch(`${tool.mcp}__${tool.action}`, params);
+            return typeof result === 'string' ? result : JSON.stringify(result);
+          };
+          try {
+            (tool as any)[method] = wrapped;
+          } catch {
+            Object.defineProperty(tool, method, { value: wrapped, writable: true });
+          }
+          restorers.push(() => {
+            try {
+              (tool as any)[method] = original;
+            } catch {
+              Object.defineProperty(tool, method, { value: original, writable: true });
+            }
+          });
+        }
+      }
+    }
+    return restorers;
+  }
+
+  async kickoff(inputs?: Record<string, any>): Promise<any> {
+    this.session = await this.issueToken();
+    const restorers = this.session ? this.patchTools(this.session) : [];
+    try {
+      if (typeof this.crew.kickoff === 'function') {
+        return await this.crew.kickoff(inputs);
+      }
+      throw new Error('The installed crewai Crew has no kickoff() method.');
+    } finally {
+      for (const r of restorers) r();
+    }
+  }
+
+  get crewaiCrew(): any {
+    return this.crew;
+  }
+}

--- a/src/integrations/google-adk.ts
+++ b/src/integrations/google-adk.ts
@@ -95,7 +95,10 @@ function buildArmorIQADKClass(): AnyCtor {
 
   return class ArmorIQADKImpl extends BasePlugin {
     private armoriqClient: ArmorIQClient;
-    private sessions = new WeakMap<object, ArmorIQSession>();
+    // Keyed by invocationId (stable string) rather than object identity,
+    // because ADK's afterModelCallback and beforeToolCallback receive
+    // different Context object instances for the same invocation.
+    private sessions = new Map<string, ArmorIQSession>();
     private opts: ArmorIQADKOptions;
 
     constructor(opts: ArmorIQADKOptions) {
@@ -139,13 +142,26 @@ function buildArmorIQADKClass(): AnyCtor {
         validitySeconds: this.opts.validitySeconds,
       });
 
-      const goal: string =
+      // ADK's userContent is a Content object ({role, parts}), not a string.
+      const rawContent =
         callbackContext?.userContent ??
-        callbackContext?.invocationContext?.userContent ??
-        'agent task';
+        callbackContext?.invocationContext?.userContent;
+      let goal = 'agent task';
+      if (typeof rawContent === 'string') {
+        goal = rawContent;
+      } else if (rawContent?.parts) {
+        const texts = rawContent.parts
+          .filter((p: any) => typeof p?.text === 'string')
+          .map((p: any) => p.text);
+        if (texts.length > 0) goal = texts.join(' ');
+      }
 
       await session.startPlan(toolCalls, { goal });
-      this.sessions.set(callbackContext, session);
+      const invocationId =
+        callbackContext?.invocationContext?.invocationId ??
+        callbackContext?.invocationId ??
+        'default';
+      this.sessions.set(invocationId, session);
       return undefined; // do not modify the LLM response
     }
 
@@ -159,11 +175,11 @@ function buildArmorIQADKClass(): AnyCtor {
       toolContext: any;
     }): Promise<Record<string, unknown> | undefined> {
       const { tool, toolArgs, toolContext } = params;
-      const ctx =
-        toolContext?.callbackContext ??
-        toolContext?.invocationContext ??
-        toolContext;
-      const session = this.sessions.get(ctx);
+      const invocationId =
+        toolContext?.invocationContext?.invocationId ??
+        toolContext?.invocationId ??
+        'default';
+      const session = this.sessions.get(invocationId);
       if (!session) return undefined; // no plan captured this turn
 
       const result = await session.dispatch(tool?.name ?? String(tool), toolArgs ?? {});

--- a/src/integrations/google-adk.ts
+++ b/src/integrations/google-adk.ts
@@ -1,0 +1,195 @@
+/**
+ * ArmorIQ — Google ADK integration.
+ *
+ * Wraps the SDK as an ADK `BasePlugin`. Plugin instance is passed to
+ * `Runner` (or `InMemoryRunner`) via `plugins: [...]`. End-user agent
+ * code is unchanged from a plain ADK setup except for:
+ *   1. one extra import
+ *   2. one `new ArmorIQADK({ ... })` line
+ *   3. passing it into the runner's `plugins` array
+ *   4. pointing MCPToolset at the Armoriq proxy URL instead of stdio
+ *
+ * Usage:
+ *
+ *   import { LlmAgent, MCPToolset, InMemoryRunner } from '@google/adk';
+ *   import { ArmorIQADK } from '@armoriq/sdk-dev/integrations/google-adk';
+ *
+ *   const armoriq = new ArmorIQADK({ apiKey: API_KEY, proxyUrl: PROXY_URL });
+ *
+ *   const agent = new LlmAgent({
+ *     model: 'gemini-2.5-flash',
+ *     name: 'stripe_agent',
+ *     instruction: 'You are a Stripe assistant.',
+ *     tools: [new MCPToolset({ ... `${PROXY_URL}/mcp/Stripe` ... })],
+ *   });
+ *
+ *   const runner = new InMemoryRunner({ agent, plugins: [armoriq] });
+ *
+ * Requires: `npm install @google/adk` alongside `@armoriq/sdk`.
+ * `@google/adk` is declared as an optional peer dep so users who don't
+ * use ADK don't pay for it.
+ */
+
+import { ArmorIQClient } from '../client';
+import { ArmorIQSession } from '../session';
+import { McpCredentialMap, ToolCall } from '../models';
+import { ToolNameParser } from '../plan-builder';
+
+// We import @google/adk lazily so consumers who don't use ADK don't
+// pay for the dep. The class extends BasePlugin via runtime resolution.
+type AnyCtor = new (...args: any[]) => any;
+
+let _BasePluginCache: AnyCtor | null = null;
+function loadBasePlugin(): AnyCtor {
+  if (_BasePluginCache) return _BasePluginCache;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const adk = require('@google/adk');
+    _BasePluginCache = adk.BasePlugin as AnyCtor;
+    if (!_BasePluginCache) {
+      throw new Error('@google/adk is installed but does not export BasePlugin.');
+    }
+    return _BasePluginCache;
+  } catch (err: any) {
+    throw new Error(
+      'ArmorIQADK requires @google/adk to be installed. ' +
+        'Install it: npm install @google/adk\n' +
+        `Underlying error: ${err?.message ?? err}`,
+    );
+  }
+}
+
+export interface ArmorIQADKOptions {
+  /** Pass an existing ArmorIQClient, OR provide apiKey to construct one. */
+  client?: ArmorIQClient;
+  apiKey?: string;
+  proxyUrl?: string;
+  userId?: string;
+  agentId?: string;
+  /** Per-MCP runtime credentials; usually loaded from env automatically. */
+  mcpCredentials?: McpCredentialMap;
+  /** Used when ADK tool names aren't namespaced as `<MCP>__<action>`. */
+  defaultMcpName?: string;
+  /** Override the default `<MCP>__<action>` parser. */
+  toolNameParser?: ToolNameParser;
+  /** LLM identifier recorded on the captured plan (audit only). */
+  llm?: string;
+  /** Token validity in seconds (default 3600). */
+  validitySeconds?: number;
+  /** Plugin name for ADK's plugin registry (default 'armoriq'). */
+  pluginName?: string;
+}
+
+/**
+ * Returns a class that extends ADK's `BasePlugin` at runtime, so the
+ * SDK doesn't have to import @google/adk at module load.
+ */
+function buildArmorIQADKClass(): AnyCtor {
+  const BasePlugin = loadBasePlugin();
+
+  return class ArmorIQADKImpl extends BasePlugin {
+    private armoriqClient: ArmorIQClient;
+    private sessions = new WeakMap<object, ArmorIQSession>();
+    private opts: ArmorIQADKOptions;
+
+    constructor(opts: ArmorIQADKOptions) {
+      super(opts.pluginName ?? 'armoriq');
+      this.opts = opts;
+      this.armoriqClient =
+        opts.client ??
+        new ArmorIQClient({
+          apiKey: opts.apiKey,
+          proxyEndpoint: opts.proxyUrl,
+          userId: opts.userId,
+          agentId: opts.agentId,
+          mcpCredentials: opts.mcpCredentials,
+        });
+    }
+
+    /**
+     * After the model returns: extract function calls, mint an intent
+     * token, stash a session keyed off the callbackContext for the
+     * matching beforeToolCallback to consume.
+     */
+    async afterModelCallback(params: {
+      callbackContext: any;
+      llmResponse: any;
+    }): Promise<any> {
+      const { callbackContext, llmResponse } = params;
+      const parts: any[] = llmResponse?.content?.parts ?? [];
+      const toolCalls: ToolCall[] = parts
+        .filter((p) => p && p.functionCall && p.functionCall.name)
+        .map((p) => ({
+          name: p.functionCall.name,
+          args: p.functionCall.args ?? {},
+        }));
+
+      if (toolCalls.length === 0) return undefined;
+
+      const session = this.armoriqClient.startSession({
+        defaultMcpName: this.opts.defaultMcpName,
+        toolNameParser: this.opts.toolNameParser,
+        llm: this.opts.llm,
+        validitySeconds: this.opts.validitySeconds,
+      });
+
+      const goal: string =
+        callbackContext?.userContent ??
+        callbackContext?.invocationContext?.userContent ??
+        'agent task';
+
+      await session.startPlan(toolCalls, { goal });
+      this.sessions.set(callbackContext, session);
+      return undefined; // do not modify the LLM response
+    }
+
+    /**
+     * Before each tool call: route through the Armoriq proxy and
+     * return the result so ADK skips its native dispatch.
+     */
+    async beforeToolCallback(params: {
+      tool: any;
+      toolArgs: Record<string, unknown>;
+      toolContext: any;
+    }): Promise<Record<string, unknown> | undefined> {
+      const { tool, toolArgs, toolContext } = params;
+      const ctx =
+        toolContext?.callbackContext ??
+        toolContext?.invocationContext ??
+        toolContext;
+      const session = this.sessions.get(ctx);
+      if (!session) return undefined; // no plan captured this turn
+
+      const result = await session.dispatch(tool?.name ?? String(tool), toolArgs ?? {});
+      // ADK expects an object; wrap primitives.
+      if (result && typeof result === 'object' && !Array.isArray(result)) {
+        return result as Record<string, unknown>;
+      }
+      return { result };
+    }
+
+    get armoriqSdk(): ArmorIQClient {
+      return this.armoriqClient;
+    }
+  };
+}
+
+let _CachedClass: AnyCtor | null = null;
+
+/**
+ * Public class. Constructed lazily so importing this module doesn't
+ * trigger the @google/adk lookup until the user actually instantiates.
+ *
+ * Use:
+ *   const armoriq = new ArmorIQADK({ apiKey, proxyUrl });
+ *   const runner = new InMemoryRunner({ agent, plugins: [armoriq] });
+ */
+export const ArmorIQADK: new (opts: ArmorIQADKOptions) => any = new Proxy(
+  function () {} as any,
+  {
+    construct(_target, args) {
+      if (!_CachedClass) _CachedClass = buildArmorIQADKClass();
+      return new _CachedClass(...args);
+    },
+  },
+) as any;

--- a/src/integrations/google-adk.ts
+++ b/src/integrations/google-adk.ts
@@ -31,7 +31,7 @@
  */
 
 import { ArmorIQClient } from '../client';
-import { ArmorIQSession } from '../session';
+import { ArmorIQSession, SessionMode } from '../session';
 import { McpCredentialMap, ToolCall } from '../models';
 import { ToolNameParser } from '../plan-builder';
 
@@ -84,6 +84,13 @@ export interface ArmorIQADKOptions {
   validitySeconds?: number;
   /** Plugin name for ADK's plugin registry (default 'armoriq'). */
   pluginName?: string;
+  /**
+   * Where the policy decision is evaluated.
+   *  - 'local' (default): SDK verifies the intent token + evaluates
+   *    policy in-process. NO proxy in the data path.
+   *  - 'proxy': SDK calls the proxy with enforce_only=true.
+   */
+  mode?: SessionMode;
 }
 
 /**
@@ -140,6 +147,7 @@ function buildArmorIQADKClass(): AnyCtor {
         toolNameParser: this.opts.toolNameParser,
         llm: this.opts.llm,
         validitySeconds: this.opts.validitySeconds,
+        mode: this.opts.mode ?? 'local',
       });
 
       // ADK's userContent is a Content object ({role, parts}), not a string.
@@ -185,7 +193,8 @@ function buildArmorIQADKClass(): AnyCtor {
       if (!session) return undefined;
 
       const toolName = tool?.name ?? String(tool);
-      const decision = await session.enforce(toolName, toolArgs ?? {});
+      // session.check() picks local vs proxy based on session.mode.
+      const decision = await session.check(toolName, toolArgs ?? {});
 
       if (!decision.allowed) {
         // Return an error result to ADK — this short-circuits the tool

--- a/src/integrations/google-adk.ts
+++ b/src/integrations/google-adk.ts
@@ -43,8 +43,14 @@ let _BasePluginCache: AnyCtor | null = null;
 function loadBasePlugin(): AnyCtor {
   if (_BasePluginCache) return _BasePluginCache;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const adk = require('@google/adk');
+    // Try multiple resolution strategies. The SDK is a dependency of
+    // the consumer, so `require('@google/adk')` from here resolves in
+    // the SDK's own node_modules (where the package isn't installed).
+    // We use createRequire from the consumer's working directory so the
+    // lookup walks the consumer's node_modules tree instead.
+    const { createRequire } = require('module') as typeof import('module');
+    const consumerRequire = createRequire(process.cwd() + '/package.json');
+    const adk = consumerRequire('@google/adk');
     _BasePluginCache = adk.BasePlugin as AnyCtor;
     if (!_BasePluginCache) {
       throw new Error('@google/adk is installed but does not export BasePlugin.');

--- a/src/integrations/google-adk.ts
+++ b/src/integrations/google-adk.ts
@@ -193,15 +193,65 @@ function buildArmorIQADKClass(): AnyCtor {
       if (!session) return undefined;
 
       const toolName = tool?.name ?? String(tool);
-      // session.check() picks local vs proxy based on session.mode.
-      const decision = await session.check(toolName, toolArgs ?? {});
+      // Pull user email if present (set by ADK runner for the request).
+      const userEmail =
+        toolContext?.userEmail ??
+        toolContext?.invocationContext?.userEmail ??
+        toolContext?.invocationContext?.userId;
+      // session.check() picks local vs proxy based on session.mode and
+      // handles the delegation flow on a 'hold' decision.
+      const decision = await session.check(toolName, toolArgs ?? {}, { userEmail });
 
       if (!decision.allowed) {
-        // Return an error result to ADK — this short-circuits the tool
-        // so the MCP is never called. The LLM sees the block reason.
+        // Mark this tool call as blocked so afterToolCallback skips
+        // its success-path audit and writes a 'failed' record instead.
+        (toolContext as any).__armoriq_blocked = decision;
+
+        // Report the block to the audit log NOW (before short-circuit)
+        // so AIGraph reflects the correct status.
+        try {
+          await session.report(toolName, toolArgs ?? {}, {
+            blocked: true,
+            reason: decision.reason,
+            action: decision.action,
+            delegationId: decision.delegationId,
+          }, {
+            status: 'failed',
+            errorMessage: decision.reason || `Blocked by policy (${decision.action})`,
+          });
+        } catch {
+          // never fail the request because audit failed
+        }
+
+        // Return a clear, structured message that the LLM can interpret
+        // and surface to the user verbatim.
+        const policy = decision.matchedPolicy ? ` (policy: ${decision.matchedPolicy})` : '';
+        let userMessage: string;
+        if (decision.action === 'hold' && decision.delegationId) {
+          userMessage =
+            `This action requires approval${policy}. ` +
+            `An approval request has been sent (id: ${decision.delegationId}). ` +
+            `Once approved, please re-run this request to proceed. ` +
+            `Reason: ${decision.reason ?? 'policy-hold'}.`;
+        } else if (decision.action === 'hold') {
+          userMessage =
+            `This action requires approval before it can run${policy}. ` +
+            `Reason: ${decision.reason ?? 'policy-hold'}.`;
+        } else {
+          userMessage =
+            `This action is not permitted by your organization's policy${policy}. ` +
+            `Reason: ${decision.reason ?? 'policy-blocked'}.`;
+        }
         return {
-          error: `Blocked by ArmorIQ policy: ${decision.reason || decision.action}`,
-          enforcement: { action: decision.action, reason: decision.reason },
+          error: userMessage,
+          armoriq_enforcement: {
+            blocked: true,
+            action: decision.action,
+            reason: decision.reason,
+            matchedPolicy: decision.matchedPolicy,
+            tool: toolName,
+            delegationId: decision.delegationId,
+          },
         };
       }
 
@@ -229,6 +279,12 @@ function buildArmorIQADKClass(): AnyCtor {
       const session = this.sessions.get(invocationId);
       if (!session) return undefined;
 
+      // If beforeToolCallback already blocked this call, the audit was
+      // written there. Don't double-audit.
+      if ((toolContext as any).__armoriq_blocked) {
+        return undefined;
+      }
+
       const toolName = tool?.name ?? String(tool);
       const startTime = (toolContext as any).__armoriq_start;
       const durationMs = startTime ? Date.now() - startTime : undefined;
@@ -240,7 +296,7 @@ function buildArmorIQADKClass(): AnyCtor {
         durationMs,
       });
 
-      return undefined; // don't modify the result
+      return undefined;
     }
 
     get armoriqSdk(): ArmorIQClient {

--- a/src/integrations/google-adk.ts
+++ b/src/integrations/google-adk.ts
@@ -166,8 +166,10 @@ function buildArmorIQADKClass(): AnyCtor {
     }
 
     /**
-     * Before each tool call: route through the Armoriq proxy and
-     * return the result so ADK skips its native dispatch.
+     * Before each tool call: enforce policy. If blocked, return an
+     * error object (short-circuits the tool). If allowed, return
+     * undefined so ADK calls the MCP directly — the agent's own
+     * MCPToolset handles the connection with its own credentials.
      */
     async beforeToolCallback(params: {
       tool: any;
@@ -180,14 +182,56 @@ function buildArmorIQADKClass(): AnyCtor {
         toolContext?.invocationId ??
         'default';
       const session = this.sessions.get(invocationId);
-      if (!session) return undefined; // no plan captured this turn
+      if (!session) return undefined;
 
-      const result = await session.dispatch(tool?.name ?? String(tool), toolArgs ?? {});
-      // ADK expects an object; wrap primitives.
-      if (result && typeof result === 'object' && !Array.isArray(result)) {
-        return result as Record<string, unknown>;
+      const toolName = tool?.name ?? String(tool);
+      const decision = await session.enforce(toolName, toolArgs ?? {});
+
+      if (!decision.allowed) {
+        // Return an error result to ADK — this short-circuits the tool
+        // so the MCP is never called. The LLM sees the block reason.
+        return {
+          error: `Blocked by ArmorIQ policy: ${decision.reason || decision.action}`,
+          enforcement: { action: decision.action, reason: decision.reason },
+        };
       }
-      return { result };
+
+      // Store start time for duration tracking in afterToolCallback
+      (toolContext as any).__armoriq_start = Date.now();
+      return undefined; // let ADK call the MCP directly
+    }
+
+    /**
+     * After each tool call: report execution to audit log.
+     * This fires AFTER the MCP returns its result — the agent called
+     * the MCP directly, and now we record what happened.
+     */
+    async afterToolCallback(params: {
+      tool: any;
+      toolArgs: Record<string, unknown>;
+      toolContext: any;
+      result: Record<string, unknown>;
+    }): Promise<Record<string, unknown> | undefined> {
+      const { tool, toolArgs, toolContext, result } = params;
+      const invocationId =
+        toolContext?.invocationContext?.invocationId ??
+        toolContext?.invocationId ??
+        'default';
+      const session = this.sessions.get(invocationId);
+      if (!session) return undefined;
+
+      const toolName = tool?.name ?? String(tool);
+      const startTime = (toolContext as any).__armoriq_start;
+      const durationMs = startTime ? Date.now() - startTime : undefined;
+
+      const hasError = result?.error || result?.isError;
+      await session.report(toolName, toolArgs ?? {}, result, {
+        status: hasError ? 'failed' : 'success',
+        errorMessage: hasError ? String(result.error || result.isError) : undefined,
+        durationMs,
+      });
+
+      return undefined; // don't modify the result
     }
 
     get armoriqSdk(): ArmorIQClient {

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1,0 +1,29 @@
+/**
+ * ArmorIQ SDK — Framework integrations.
+ *
+ * Mirrors the shape of armoriq_sdk.integrations in the Python SDK.
+ * Each integration is importable on its own subpath so consumers only
+ * pay for the peer dep they actually use, e.g.:
+ *
+ *   import { ArmorIQADK }      from '@armoriq/sdk-dev/integrations/google-adk';
+ *   import { ArmorIQCrew }     from '@armoriq/sdk-dev/integrations/crewai';
+ *   import { ArmorIQLangChain } from '@armoriq/sdk-dev/integrations/langchain';
+ *   import { ArmorIQOpenAI }   from '@armoriq/sdk-dev/integrations/openai';
+ *   import { ArmorIQAnthropic } from '@armoriq/sdk-dev/integrations/anthropic';
+ *
+ * Availability:
+ *   google-adk → real            (wraps ADK's BasePlugin)
+ *   crewai     → real (port)     (wraps CrewAI Crew.kickoff)
+ *   langchain  → Coming Soon
+ *   openai     → Coming Soon
+ *   anthropic  → Coming Soon
+ *
+ * Vertex AI: no separate file — Vertex agents run under Google ADK, so
+ * ArmorIQADK covers Vertex too.
+ */
+
+export { ArmorIQADK, ArmorIQADKOptions } from './google-adk';
+export { ArmorIQCrew, ArmorIQCrewOptions } from './crewai';
+export { ArmorIQLangChain, ArmorIQLangChainOptions } from './langchain';
+export { ArmorIQOpenAI, ArmorIQOpenAIOptions } from './openai';
+export { ArmorIQAnthropic, ArmorIQAnthropicOptions } from './anthropic';

--- a/src/integrations/langchain.ts
+++ b/src/integrations/langchain.ts
@@ -1,0 +1,33 @@
+/**
+ * ArmorIQ — LangChain integration. (Coming Soon)
+ *
+ * Planned surface mirrors the Python SDK's ArmorIQLangChain (currently
+ * stubbed in Python too). When implemented, this will wrap LangChain.js
+ * `StructuredTool` / `Tool` instances so their `invoke()` routes through
+ * the Armoriq proxy via ArmorIQSession.
+ *
+ * Requires: `npm install @langchain/core langchain`
+ */
+
+import { ArmorIQClient } from '../client';
+
+export interface ArmorIQLangChainOptions {
+  armoriqClient: ArmorIQClient;
+  llm?: string;
+  [key: string]: any;
+}
+
+export class ArmorIQLangChain {
+  constructor(_options: ArmorIQLangChainOptions) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('@langchain/core');
+    } catch {
+      throw new Error(
+        '@langchain/core is not installed.\n' +
+          'Install it with: npm install @langchain/core langchain',
+      );
+    }
+    throw new Error('ArmorIQ LangChain integration is not yet implemented.');
+  }
+}

--- a/src/integrations/openai.ts
+++ b/src/integrations/openai.ts
@@ -1,0 +1,32 @@
+/**
+ * ArmorIQ — OpenAI integration. (Coming Soon)
+ *
+ * Mirrors the Python SDK's ArmorIQOpenAI stub. When implemented, this
+ * will wrap the OpenAI SDK's tool-call dispatch (and/or the OpenAI
+ * Agents runtime) so tool calls route through the Armoriq proxy via
+ * ArmorIQSession.
+ *
+ * Requires: `npm install openai`
+ */
+
+import { ArmorIQClient } from '../client';
+
+export interface ArmorIQOpenAIOptions {
+  armoriqClient: ArmorIQClient;
+  [key: string]: any;
+}
+
+export class ArmorIQOpenAI {
+  constructor(_options: ArmorIQOpenAIOptions) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('openai');
+    } catch {
+      throw new Error(
+        'openai is not installed.\n' +
+          'Install it with: npm install openai',
+      );
+    }
+    throw new Error('ArmorIQ OpenAI integration is not yet implemented.');
+  }
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -255,6 +255,34 @@ export interface ApprovedDelegation {
 }
 
 /**
+ * A single tool call as surfaced by an LLM framework (ADK, LangChain,
+ * OpenAI Agents, Vercel AI SDK, etc.). Used by ArmorIQSession to capture
+ * a plan without making the caller hand-build the SDK plan shape.
+ */
+export interface ToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Credential for an upstream MCP. Forwarded per-call to the proxy via
+ * the X-Armoriq-MCP-Auth header. The proxy injects the appropriate
+ * upstream auth header and drops this one before forwarding. Armoriq
+ * does NOT store these.
+ */
+export type McpCredential =
+  | { authType: 'bearer'; token: string }
+  | { authType: 'api_key'; apiKey: string; headerName?: string }
+  | { authType: 'basic'; username: string; password: string }
+  | { authType: 'none' };
+
+/**
+ * Map of MCP identifier (the name registered on the platform) to its
+ * runtime credential.
+ */
+export type McpCredentialMap = Record<string, McpCredential>;
+
+/**
  * SDK configuration.
  */
 export interface SDKConfig {
@@ -282,4 +310,6 @@ export interface SDKConfig {
   apiKey?: string;
   /** Use production endpoints */
   useProduction: boolean;
+  /** Per-MCP runtime credentials (agent-managed cred path) */
+  mcpCredentials?: McpCredentialMap;
 }

--- a/src/plan-builder.ts
+++ b/src/plan-builder.ts
@@ -1,0 +1,81 @@
+/**
+ * Plan-shape helpers used by ArmorIQSession and framework integrations.
+ *
+ * Most LLM frameworks surface tool calls as a flat list of
+ * `{ name, args }`. The SDK accepts that shape directly so plugin code
+ * doesn't have to hand-construct `{ goal, steps: [...] }` every time.
+ */
+
+import * as crypto from 'crypto';
+import { ToolCall } from './models';
+
+export interface ToolNameParser {
+  (toolName: string): { mcp: string; action: string };
+}
+
+export interface BuildPlanOptions {
+  goal?: string;
+  toolNameParser?: ToolNameParser;
+  defaultMcpName?: string;
+}
+
+/**
+ * Default tool-name convention: `<MCP>__<action>`. Matches the proxy's
+ * MCP gateway and the convention used by sdk-admin-agent.
+ *   "Stripe__create_payment" -> { mcp: "Stripe", action: "create_payment" }
+ *   "create_payment"          -> uses defaultMcpName, else throws.
+ */
+export function defaultToolNameParser(defaultMcpName?: string): ToolNameParser {
+  return (toolName: string) => {
+    const idx = toolName.indexOf('__');
+    if (idx === -1) {
+      if (!defaultMcpName) {
+        throw new Error(
+          `Tool "${toolName}" is not namespaced as <MCP>__<action> and no defaultMcpName was set on the session.`,
+        );
+      }
+      return { mcp: defaultMcpName, action: toolName };
+    }
+    const mcp = toolName.slice(0, idx);
+    const action = toolName.slice(idx + 2);
+    if (!mcp || !action) {
+      throw new Error(`Tool "${toolName}" has a malformed MCP prefix.`);
+    }
+    return { mcp, action };
+  };
+}
+
+/**
+ * Build a SDK-shaped plan dict from a flat list of tool calls.
+ */
+export function buildPlanFromToolCalls(
+  toolCalls: ToolCall[],
+  opts: BuildPlanOptions = {},
+): Record<string, any> {
+  const parser = opts.toolNameParser ?? defaultToolNameParser(opts.defaultMcpName);
+  const steps = toolCalls.map((tc) => {
+    const { mcp, action } = parser(tc.name);
+    return {
+      action,
+      tool: action,
+      mcp,
+      params: tc.args ?? {},
+      description: `Call ${action} on ${mcp}`,
+    };
+  });
+  return {
+    goal: opts.goal ?? 'agent task',
+    steps,
+  };
+}
+
+/**
+ * Stable hash over a tool-calls list — used by the session to skip
+ * re-minting when the LLM re-emits the same plan in the same turn.
+ */
+export function hashToolCalls(toolCalls: ToolCall[]): string {
+  const canonical = JSON.stringify(
+    toolCalls.map((tc) => ({ name: tc.name, args: tc.args ?? {} })),
+  );
+  return crypto.createHash('sha256').update(canonical, 'utf8').digest('hex');
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -220,13 +220,6 @@ export class ArmorIQSession {
       governingEntry?.defaultEnforcementAction ||
       pv?.default_enforcement_action ||
       'block';
-    // For threshold violations on an allowed tool, the per-rule action
-    // applies (e.g. 'hold' to require approval for amounts > $50).
-    const conditionalAction =
-      governingRule?.enforcementAction ||
-      governingEntry?.defaultEnforcementAction ||
-      pv?.default_enforcement_action ||
-      'hold';
 
     // 3. denied_tools — explicit deny list from backend evaluation.
     //    Only treat as a deny IF we found a governing policy for this tool.
@@ -287,24 +280,19 @@ export class ArmorIQSession {
       }
     }
 
-    // 5. Threshold checks on the governing rule (e.g. amount limits)
+    // 5. Threshold checks on the governing rule (e.g. amount limits).
+    //    Uses tool metadata declared on the platform (amountFields +
+    //    amountUnit, set in armorpay's tool-metadata UI) — NO MCP-
+    //    specific knowledge in the SDK itself.
     if (governingRule) {
-      const fin =
-        governingRule.financialRule?.amountThreshold ??
-        governingRule.amountThreshold;
-      if (fin && typeof fin === 'object') {
-        for (const [field, threshold] of Object.entries(fin)) {
-          if (typeof threshold !== 'number') continue;
-          const argVal = Number((toolArgs as any)?.[field]);
-          if (!isNaN(argVal) && argVal > Number(threshold)) {
-            return {
-              allowed: false,
-              action: conditionalAction === 'block' ? 'block' : 'hold',
-              reason: `Amount ${argVal} exceeds threshold ${threshold} for field '${field}'`,
-              matchedPolicy: governingPolicyName,
-            };
-          }
-        }
+      const decision = await this.evaluateAmountThreshold(
+        governingRule,
+        toolArgs,
+        action,
+        mcp,
+      );
+      if (decision) {
+        return { ...decision, matchedPolicy: governingPolicyName };
       }
     }
 
@@ -596,13 +584,87 @@ export class ArmorIQSession {
     };
   }
 
-  /** Best-effort extraction of an amount field from arbitrary tool args. */
+  /**
+   * Best-effort extraction of an amount field from arbitrary tool args.
+   * Used as a FALLBACK when the platform hasn't declared per-tool
+   * metadata. Fully MCP-agnostic — only checks generic field names.
+   */
   private extractAmount(args: Record<string, unknown>): number | undefined {
     if (!args || typeof args !== 'object') return undefined;
-    const candidates = ['amount', 'unit_amount', 'value', 'total', 'price', 'cost'];
+    const candidates = ['amount', 'value', 'total', 'price', 'cost'];
     for (const k of candidates) {
       const v = (args as any)[k];
       if (v != null && !isNaN(Number(v))) return Number(v);
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve the canonical "amount" for a tool call:
+   *   1. Try platform-declared tool metadata (amountFields + amountUnit)
+   *      — same source the proxy uses (toolMetadata column on MCPServer,
+   *      authored in the armorpay UI). MCP-specific units like 'cents'
+   *      are normalized HERE, not in the SDK.
+   *   2. Fall back to the generic candidate-field extractor.
+   */
+  private async resolveCanonicalAmount(
+    mcp: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<number | undefined> {
+    try {
+      const meta = await this.client.fetchToolMetadata(mcp);
+      const toolMeta = meta?.toolMetadata?.[toolName];
+      if (toolMeta?.amountFields?.length) {
+        for (const field of toolMeta.amountFields) {
+          const raw = (args as any)?.[field];
+          if (raw == null || isNaN(Number(raw))) continue;
+          const num = Number(raw);
+          return toolMeta.amountUnit === 'cents' ? num / 100 : num;
+        }
+      }
+    } catch {
+      // metadata fetch failed — fall through to generic extraction
+    }
+    return this.extractAmount(args);
+  }
+
+  /**
+   * Evaluate an amount-threshold rule from the policy snapshot against
+   * the tool args. Returns:
+   *   - undefined if no threshold or amount-not-applicable
+   *   - { allowed: false, action: 'block' } if amount > maxPerTransaction
+   *   - { allowed: false, action: 'hold'  } if amount > requireApprovalAbove
+   */
+  private async evaluateAmountThreshold(
+    rule: any,
+    toolArgs: Record<string, unknown>,
+    action: string,
+    mcp: string,
+  ): Promise<{ allowed: false; action: 'block' | 'hold'; reason: string } | undefined> {
+    const fin = rule?.financialRule?.amountThreshold ?? rule?.amountThreshold;
+    if (!fin || typeof fin !== 'object') return undefined;
+
+    const amount = await this.resolveCanonicalAmount(mcp, action, toolArgs);
+    if (amount === undefined) return undefined;
+
+    const currency = (fin as any).currency || '';
+    const maxPer = (fin as any).maxPerTransaction;
+    const reqApproval = (fin as any).requireApprovalAbove;
+
+    if (typeof maxPer === 'number' && amount > maxPer) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: `Amount ${amount} ${currency} exceeds maxPerTransaction (${maxPer})`.trim(),
+      };
+    }
+    if (typeof reqApproval === 'number' && amount > reqApproval) {
+      return {
+        allowed: false,
+        action: 'hold',
+        reason: `Amount ${amount} ${currency} requires approval (threshold: ${reqApproval})`.trim(),
+      };
     }
     return undefined;
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -473,32 +473,38 @@ export class ArmorIQSession {
    * Mode-aware enforcement entry point. Plugins should call this and
    * not branch themselves — `mode` on the session decides the path.
    *
-   * On a 'hold' decision in local mode, this also handles the
-   * "Option B" delegation flow:
-   *   1. First time the tool is seen → create delegation request,
-   *      return block decision with delegationId (UI shows approval card)
-   *   2. Subsequent attempts (next user prompt / re-plan) → check if the
-   *      delegation was approved; if yes, allow; if rejected, block;
-   *      if still pending, return hold again.
-   *
-   * Approvals expire by default after 30 minutes (configurable on the
-   * platform per delegation request). The plugin should re-prompt the
-   * user after this window.
+   * Behavior by mode:
+   *   - 'local'  → allow / block ONLY. In-process, no network calls.
+   *                A 'hold' threshold violation is reported as 'block'
+   *                with an explanatory reason. Use proxy mode if you
+   *                need delegation/approval workflows.
+   *   - 'proxy'  → allow / block / hold. The proxy resolves the hold
+   *                via the delegation pipeline (request → approve → re-run).
    */
   async check(
     toolName: string,
     toolArgs: Record<string, unknown>,
     opts: { userEmail?: string } = {},
   ): Promise<EnforceResult> {
-    const decision =
-      this.mode === 'proxy'
-        ? await this.enforce(toolName, toolArgs)
-        : await this.enforceLocal(toolName, toolArgs);
+    if (this.mode === 'local') {
+      const decision = await this.enforceLocal(toolName, toolArgs);
+      // Local mode is allow/block only — downgrade any 'hold' to 'block'
+      // so the agent UX is clear: action requires a more permissive mode.
+      if (decision.action === 'hold') {
+        return {
+          ...decision,
+          action: 'block',
+          reason:
+            (decision.reason ?? 'requires approval') +
+            ' — switch ARMORIQ_MODE=proxy to enable approval workflows for this action.',
+        };
+      }
+      return decision;
+    }
 
-    // Plain allow / block — return as-is
+    // Proxy mode: full pipeline including hold + delegation.
+    const decision = await this.enforce(toolName, toolArgs);
     if (decision.action !== 'hold') return decision;
-
-    // 'hold' decision → run the delegation flow (Option B async).
     return this.handleHold(toolName, toolArgs, decision, opts);
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -182,10 +182,39 @@ export class ArmorIQSession {
       };
     }
 
-    // 3. allowed_tools list from the JWT's policy_validation
-    const allowedTools: string[] | undefined =
-      this.currentTokenValue.policyValidation?.allowed_tools;
-    if (Array.isArray(allowedTools) && allowedTools.length > 0) {
+    const pv = this.currentTokenValue.policyValidation;
+    const matchedPolicyName = pv?.matched_policies?.[0]?.name;
+    const defaultAction =
+      pv?.default_enforcement_action ||
+      pv?.matched_policies?.[0]?.default_enforcement_action ||
+      'block';
+
+    // 3. denied_tools (explicit deny list from backend evaluation)
+    const deniedTools: string[] | undefined = pv?.denied_tools;
+    if (Array.isArray(deniedTools)) {
+      const denied =
+        deniedTools.includes(toolName) || deniedTools.includes(action);
+      if (denied) {
+        const reason =
+          pv?.denied_reasons?.find((r: string) =>
+            r.startsWith(`${action}:`) || r.startsWith(`${toolName}:`),
+          ) || `Tool '${action}' is denied by policy '${matchedPolicyName ?? 'unknown'}'`;
+        return {
+          allowed: false,
+          action: defaultAction === 'hold' ? 'hold' : 'block',
+          reason,
+          matchedPolicy: matchedPolicyName,
+        };
+      }
+    }
+
+    // 4. allowed_tools (explicit allow list — must include this tool)
+    // The backend returns allowed_tools as the subset of REQUESTED tools
+    // that the policy allows. If our tool isn't in there AND there are
+    // matched policies, treat it as a deny.
+    const allowedTools: string[] | undefined = pv?.allowed_tools;
+    const hasMatchedPolicies = (pv?.matched_policies?.length ?? 0) > 0;
+    if (Array.isArray(allowedTools) && hasMatchedPolicies) {
       const wildcard = allowedTools.includes('*');
       const ok =
         wildcard ||
@@ -194,47 +223,64 @@ export class ArmorIQSession {
       if (!ok) {
         return {
           allowed: false,
-          action: 'block',
-          reason: `Tool '${action}' is not in the policy's allowed_tools`,
-          matchedPolicy: this.currentTokenValue.policyValidation?.matched_policies?.[0]?.name,
+          action: defaultAction === 'hold' ? 'hold' : 'block',
+          reason: `Tool '${action}' is not in the allowed tools for policy '${matchedPolicyName ?? 'unknown'}'`,
+          matchedPolicy: matchedPolicyName,
         };
       }
     }
 
-    // 4. Local policy snapshot evaluation (financial thresholds, etc.)
+    // 5. Policy snapshot — walk the OPA-formatted rules for thresholds
+    //    Snapshot shape (per iap-policy-decision.service.ts:582-596):
+    //      { policyId, policyName, memberRule: { allowedTools, ... }, clientRule: ... }
     const snapshot = this.currentTokenValue.policySnapshot;
     if (Array.isArray(snapshot)) {
       for (const entry of snapshot) {
-        const rules = (entry as any)?.rules ?? entry;
-        const memberRules =
-          rules?.memberRules ?? (rules as any)?.['*'] ?? rules;
-        const allowed: string[] | undefined = memberRules?.allowedTools;
-        if (Array.isArray(allowed) && allowed.length > 0) {
-          const wildcard = allowed.includes('*');
-          const ok = wildcard || allowed.includes(action);
+        const rule =
+          (entry as any)?.memberRule ??
+          (entry as any)?.clientRule ??
+          (entry as any)?.rules ??
+          (entry as any)?.memberRules?.['*'] ??
+          entry;
+        if (!rule) continue;
+
+        // 5a. Snapshot allowedTools — same logic as #4 but per-policy
+        const ruleAllowed: string[] | undefined = rule.allowedTools;
+        if (Array.isArray(ruleAllowed) && ruleAllowed.length > 0) {
+          const wildcard = ruleAllowed.includes('*');
+          const ok = wildcard || ruleAllowed.includes(action);
           if (!ok) {
+            const enforcementAction =
+              rule.enforcementAction ||
+              (entry as any)?.defaultEnforcementAction ||
+              defaultAction;
             return {
               allowed: false,
-              action: 'block',
-              reason: `Tool '${action}' not in policy snapshot allowedTools`,
+              action: enforcementAction === 'hold' ? 'hold' : 'block',
+              reason: `Tool '${action}' not allowed by policy '${(entry as any)?.policyName ?? 'unknown'}'`,
+              matchedPolicy: (entry as any)?.policyName,
             };
           }
         }
-        // Amount-threshold check
-        const fin = memberRules?.financialRule?.amountThreshold;
+
+        // 5b. Amount-threshold check
+        const fin = rule.financialRule?.amountThreshold ?? rule.amountThreshold;
         if (fin && typeof fin === 'object') {
+          // Common field names: amount, value, total, etc. Walk the args.
           for (const [field, threshold] of Object.entries(fin)) {
+            // Skip non-numeric meta fields
+            if (typeof threshold !== 'number') continue;
             const argVal = Number((toolArgs as any)?.[field]);
             if (!isNaN(argVal) && argVal > Number(threshold)) {
               const enforcementAction =
-                memberRules?.enforcementAction ||
+                rule.enforcementAction ||
                 (entry as any)?.defaultEnforcementAction ||
                 'hold';
               return {
                 allowed: false,
-                action:
-                  enforcementAction === 'block' ? 'block' : 'hold',
-                reason: `Amount ${argVal} exceeds threshold ${threshold} for field ${field}`,
+                action: enforcementAction === 'block' ? 'block' : 'hold',
+                reason: `Amount ${argVal} exceeds threshold ${threshold} for field '${field}'`,
+                matchedPolicy: (entry as any)?.policyName,
               };
             }
           }
@@ -246,6 +292,7 @@ export class ArmorIQSession {
       allowed: true,
       action: 'allow',
       reason: 'Allowed by local policy evaluation',
+      matchedPolicy: matchedPolicyName,
     };
   }
 
@@ -417,14 +464,127 @@ export class ArmorIQSession {
   /**
    * Mode-aware enforcement entry point. Plugins should call this and
    * not branch themselves — `mode` on the session decides the path.
+   *
+   * On a 'hold' decision in local mode, this also handles the
+   * "Option B" delegation flow:
+   *   1. First time the tool is seen → create delegation request,
+   *      return block decision with delegationId (UI shows approval card)
+   *   2. Subsequent attempts (next user prompt / re-plan) → check if the
+   *      delegation was approved; if yes, allow; if rejected, block;
+   *      if still pending, return hold again.
+   *
+   * Approvals expire by default after 30 minutes (configurable on the
+   * platform per delegation request). The plugin should re-prompt the
+   * user after this window.
    */
   async check(
     toolName: string,
     toolArgs: Record<string, unknown>,
+    opts: { userEmail?: string } = {},
   ): Promise<EnforceResult> {
-    return this.mode === 'proxy'
-      ? this.enforce(toolName, toolArgs)
-      : this.enforceLocal(toolName, toolArgs);
+    const decision =
+      this.mode === 'proxy'
+        ? await this.enforce(toolName, toolArgs)
+        : await this.enforceLocal(toolName, toolArgs);
+
+    // Plain allow / block — return as-is
+    if (decision.action !== 'hold') return decision;
+
+    // 'hold' decision → run the delegation flow (Option B async).
+    return this.handleHold(toolName, toolArgs, decision, opts);
+  }
+
+  /**
+   * Handle a 'hold' decision: check for prior approval, otherwise
+   * create a delegation request. Returns either:
+   *   - allowed: true (prior approval found within window)
+   *   - allowed: false, action: 'hold', delegationId (request created or pending)
+   */
+  private async handleHold(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+    holdDecision: EnforceResult,
+    opts: { userEmail?: string } = {},
+  ): Promise<EnforceResult> {
+    const userEmail =
+      opts.userEmail ||
+      (this.client as any).userId ||
+      'unknown@armoriq';
+    const { mcp, action } = this.toolNameParser(toolName);
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+
+    // 1. Check if there's already an approved delegation for this
+    //    (user, tool, amount) within the approval window.
+    const amount = this.extractAmount(toolArgs);
+    try {
+      const approved = await this.client.checkApprovedDelegation(
+        userEmail,
+        action,
+        amount ?? 0,
+      );
+      if (approved && (approved as any).approved !== false) {
+        // Mark used so a single approval = single execution
+        try {
+          if ((approved as any).delegationId) {
+            await this.client.markDelegationExecuted(
+              userEmail,
+              (approved as any).delegationId,
+            );
+          }
+        } catch {
+          // best-effort
+        }
+        return {
+          allowed: true,
+          action: 'allow',
+          reason: `Allowed by approved delegation ${(approved as any).delegationId ?? ''}`.trim(),
+          delegationId: (approved as any).delegationId,
+          matchedPolicy: holdDecision.matchedPolicy,
+        };
+      }
+    } catch {
+      // backend unreachable — fall through to creating a new request
+    }
+
+    // 2. No prior approval → create a delegation request (visible in UI).
+    let delegationId: string | undefined;
+    try {
+      const result = await this.client.createDelegationRequest({
+        tool: action,
+        action,
+        arguments: toolArgs,
+        amount,
+        requesterEmail: userEmail,
+        domain: resolvedMcp,
+        planId: this.currentTokenValue?.planId,
+        intentReference: this.currentTokenValue?.tokenId,
+        merkleRoot: (this.currentTokenValue as any)?.rawToken?.merkle_root,
+        reason: holdDecision.reason,
+      });
+      delegationId = (result as any)?.delegationId;
+    } catch (err: any) {
+      // If we can't create the request, still return the original block.
+      console.warn(`[ArmorIQ] createDelegationRequest failed: ${err.message}`);
+    }
+
+    return {
+      allowed: false,
+      action: 'hold',
+      reason: holdDecision.reason ?? 'Pending approval',
+      delegationId,
+      matchedPolicy: holdDecision.matchedPolicy,
+    };
+  }
+
+  /** Best-effort extraction of an amount field from arbitrary tool args. */
+  private extractAmount(args: Record<string, unknown>): number | undefined {
+    if (!args || typeof args !== 'object') return undefined;
+    const candidates = ['amount', 'value', 'total', 'price', 'cost'];
+    for (const k of candidates) {
+      const v = (args as any)[k];
+      if (v != null && !isNaN(Number(v))) return Number(v);
+    }
+    return undefined;
   }
 
   /** Drop cached plan + token so the next startPlan() always mints fresh. */

--- a/src/session.ts
+++ b/src/session.ts
@@ -183,108 +183,119 @@ export class ArmorIQSession {
     }
 
     const pv = this.currentTokenValue.policyValidation;
-    const matchedPolicyName =
-      pv?.matched_policies?.[0]?.policyName ||
-      pv?.matched_policies?.[0]?.name;
-    const defaultAction =
+    const snapshot = this.currentTokenValue.policySnapshot;
+
+    // Find the policy that ACTUALLY governs this tool by walking the
+    // snapshot — `matched_policies` is the union for the whole plan
+    // (may include unrelated MCPs' policies that ran in the same eval).
+    // The policy whose allowedTools include this action OR which
+    // explicitly mentions this tool in its rules is "ours".
+    const ruleOf = (entry: any) =>
+      entry?.memberRule ?? entry?.clientRule ?? entry?.rules ?? entry;
+    const governingEntry = Array.isArray(snapshot)
+      ? snapshot.find((entry: any) => {
+          const r = ruleOf(entry);
+          if (!r) return false;
+          const allowed: string[] = Array.isArray(r.allowedTools) ? r.allowedTools : [];
+          // A policy "governs" this tool if either:
+          //   - the action is in its allowedTools (positive match)
+          //   - the action would have been in scope by tool prefix match
+          //     (some policies use namespaced names, e.g. "GitHub__search_*")
+          if (allowed.includes(action) || allowed.includes(toolName)) return true;
+          if (allowed.some((t) => t === '*' || t.endsWith('/*') || t.endsWith('*'))) return true;
+          // Fall back to MCP/target name match if we can find one
+          const target = (entry?.targetName || entry?.policyName || '').toLowerCase();
+          return target.includes(mcp.toLowerCase());
+        })
+      : undefined;
+
+    const governingRule = ruleOf(governingEntry);
+    const governingPolicyName = governingEntry?.policyName;
+    const governingDefaultAction =
+      governingRule?.enforcementAction ||
+      governingEntry?.defaultEnforcementAction ||
       pv?.default_enforcement_action ||
-      pv?.matched_policies?.[0]?.default_enforcement_action ||
       'block';
 
-    // 3. denied_tools (explicit deny list from backend evaluation)
+    // 3. denied_tools — explicit deny list from backend evaluation.
+    //    Only treat as a deny IF we found a governing policy for this tool.
     const deniedTools: string[] | undefined = pv?.denied_tools;
     if (Array.isArray(deniedTools)) {
       const denied =
         deniedTools.includes(toolName) || deniedTools.includes(action);
       if (denied) {
+        const reasonFromBackend = pv?.denied_reasons?.find((r: string) =>
+          r.startsWith(`${action}:`) || r.startsWith(`${toolName}:`),
+        );
         const reason =
-          pv?.denied_reasons?.find((r: string) =>
-            r.startsWith(`${action}:`) || r.startsWith(`${toolName}:`),
-          ) || `Tool '${action}' is denied by policy '${matchedPolicyName ?? 'unknown'}'`;
+          reasonFromBackend ||
+          (governingPolicyName
+            ? `Tool '${action}' is denied by policy '${governingPolicyName}'`
+            : `Tool '${action}' is denied by policy`);
         return {
           allowed: false,
-          action: defaultAction === 'hold' ? 'hold' : 'block',
+          action: governingDefaultAction === 'hold' ? 'hold' : 'block',
           reason,
-          matchedPolicy: matchedPolicyName,
+          matchedPolicy: governingPolicyName,
         };
       }
     }
 
-    // 4. allowed_tools (explicit allow list — must include this tool)
-    // The backend returns allowed_tools as the subset of REQUESTED tools
-    // that the policy allows. If our tool isn't in there AND there are
-    // matched policies, treat it as a deny.
-    const allowedTools: string[] | undefined = pv?.allowed_tools;
-    const hasMatchedPolicies = (pv?.matched_policies?.length ?? 0) > 0;
-    if (Array.isArray(allowedTools) && hasMatchedPolicies) {
-      const wildcard = allowedTools.includes('*');
-      const ok =
-        wildcard ||
-        allowedTools.includes(toolName) ||
-        allowedTools.includes(action);
-      if (!ok) {
+    // 4. Snapshot-based check using the governing policy.
+    if (governingRule) {
+      const allowed: string[] = Array.isArray(governingRule.allowedTools)
+        ? governingRule.allowedTools
+        : [];
+      if (allowed.length > 0) {
+        const wildcard = allowed.includes('*');
+        const ok =
+          wildcard ||
+          allowed.includes(action) ||
+          allowed.includes(toolName);
+        if (!ok) {
+          return {
+            allowed: false,
+            action: governingDefaultAction === 'hold' ? 'hold' : 'block',
+            reason: `Tool '${action}' is not in the allowed tools for policy '${governingPolicyName}'`,
+            matchedPolicy: governingPolicyName,
+          };
+        }
+      }
+    } else if (Array.isArray(snapshot) && snapshot.length > 0) {
+      // We have policies but none govern this tool — for an MCP that has
+      // an explicit policy attached, this means "no rule allows it".
+      // Don't false-positive on unrelated MCP policies though: only
+      // block if `allowed_tools` from the backend is empty for this tool.
+      const allowedTools: string[] | undefined = pv?.allowed_tools;
+      if (Array.isArray(allowedTools) && allowedTools.length === 0) {
         return {
           allowed: false,
-          action: defaultAction === 'hold' ? 'hold' : 'block',
-          reason: `Tool '${action}' is not in the allowed tools for policy '${matchedPolicyName ?? 'unknown'}'`,
-          matchedPolicy: matchedPolicyName,
+          action: 'block',
+          reason: `Tool '${action}' is not allowed by any policy in scope`,
         };
       }
     }
 
-    // 5. Policy snapshot — walk the OPA-formatted rules for thresholds
-    //    Snapshot shape (per iap-policy-decision.service.ts:582-596):
-    //      { policyId, policyName, memberRule: { allowedTools, ... }, clientRule: ... }
-    const snapshot = this.currentTokenValue.policySnapshot;
-    if (Array.isArray(snapshot)) {
-      for (const entry of snapshot) {
-        const rule =
-          (entry as any)?.memberRule ??
-          (entry as any)?.clientRule ??
-          (entry as any)?.rules ??
-          (entry as any)?.memberRules?.['*'] ??
-          entry;
-        if (!rule) continue;
-
-        // 5a. Snapshot allowedTools — same logic as #4 but per-policy
-        const ruleAllowed: string[] | undefined = rule.allowedTools;
-        if (Array.isArray(ruleAllowed) && ruleAllowed.length > 0) {
-          const wildcard = ruleAllowed.includes('*');
-          const ok = wildcard || ruleAllowed.includes(action);
-          if (!ok) {
+    // 5. Threshold checks on the governing rule (e.g. amount limits)
+    if (governingRule) {
+      const fin =
+        governingRule.financialRule?.amountThreshold ??
+        governingRule.amountThreshold;
+      if (fin && typeof fin === 'object') {
+        for (const [field, threshold] of Object.entries(fin)) {
+          if (typeof threshold !== 'number') continue;
+          const argVal = Number((toolArgs as any)?.[field]);
+          if (!isNaN(argVal) && argVal > Number(threshold)) {
             const enforcementAction =
-              rule.enforcementAction ||
-              (entry as any)?.defaultEnforcementAction ||
-              defaultAction;
+              governingRule.enforcementAction ||
+              governingEntry?.defaultEnforcementAction ||
+              'hold';
             return {
               allowed: false,
-              action: enforcementAction === 'hold' ? 'hold' : 'block',
-              reason: `Tool '${action}' not allowed by policy '${(entry as any)?.policyName ?? 'unknown'}'`,
-              matchedPolicy: (entry as any)?.policyName,
+              action: enforcementAction === 'block' ? 'block' : 'hold',
+              reason: `Amount ${argVal} exceeds threshold ${threshold} for field '${field}'`,
+              matchedPolicy: governingPolicyName,
             };
-          }
-        }
-
-        // 5b. Amount-threshold check
-        const fin = rule.financialRule?.amountThreshold ?? rule.amountThreshold;
-        if (fin && typeof fin === 'object') {
-          // Common field names: amount, value, total, etc. Walk the args.
-          for (const [field, threshold] of Object.entries(fin)) {
-            // Skip non-numeric meta fields
-            if (typeof threshold !== 'number') continue;
-            const argVal = Number((toolArgs as any)?.[field]);
-            if (!isNaN(argVal) && argVal > Number(threshold)) {
-              const enforcementAction =
-                rule.enforcementAction ||
-                (entry as any)?.defaultEnforcementAction ||
-                'hold';
-              return {
-                allowed: false,
-                action: enforcementAction === 'block' ? 'block' : 'hold',
-                reason: `Amount ${argVal} exceeds threshold ${threshold} for field '${field}'`,
-                matchedPolicy: (entry as any)?.policyName,
-              };
-            }
           }
         }
       }
@@ -294,7 +305,7 @@ export class ArmorIQSession {
       allowed: true,
       action: 'allow',
       reason: 'Allowed by local policy evaluation',
-      matchedPolicy: matchedPolicyName,
+      matchedPolicy: governingPolicyName,
     };
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -24,11 +24,22 @@ import {
   hashToolCalls,
 } from './plan-builder';
 
+export type SessionMode = 'local' | 'proxy';
+
 export interface SessionOptions {
   toolNameParser?: ToolNameParser;
   defaultMcpName?: string;
   validitySeconds?: number;
   llm?: string;
+  /**
+   * Where the policy decision is evaluated.
+   *  - 'local' (default): SDK verifies the intent token signature in-process
+   *    and evaluates the policy snapshot locally. NO network call to the
+   *    proxy on the tool-call hot path.
+   *  - 'proxy': SDK calls the proxy with enforce_only=true. Useful when
+   *    you want centralized real-time policy decisions or shared rate limits.
+   */
+  mode?: SessionMode;
 }
 
 export interface EnforceResult {
@@ -54,11 +65,23 @@ export class ArmorIQSession {
   private defaultMcpName?: string;
   private validitySeconds: number;
   private llm: string;
+  private mode: SessionMode;
   private stepIndex: number = 0;
 
   private currentPlanHash: string | null = null;
   private currentTokenValue: IntentToken | null = null;
   private mcpByAction: Map<string, string> = new Map();
+
+  // Plan-binding: every tool the agent is allowed to invoke this turn.
+  // Keys are BOTH the framework's tool name (e.g. "GitHub__search_repositories")
+  // and the parsed action name (e.g. "search_repositories") so either matches.
+  private declaredTools: Set<string> = new Set();
+
+  // Cached IAP public key per kid (one HTTP call per process per key).
+  private static publicKeyCache: Map<
+    string,
+    { publicKey: string; algorithm: string }
+  > = new Map();
 
   constructor(client: ArmorIQClient, opts: SessionOptions = {}) {
     this.client = client;
@@ -67,6 +90,7 @@ export class ArmorIQSession {
       opts.toolNameParser ?? defaultToolNameParser(this.defaultMcpName);
     this.validitySeconds = opts.validitySeconds ?? 3600;
     this.llm = opts.llm ?? 'agent';
+    this.mode = opts.mode ?? 'local';
   }
 
   /**
@@ -94,8 +118,16 @@ export class ArmorIQSession {
     });
 
     this.mcpByAction.clear();
+    this.declaredTools.clear();
     for (const step of plan.steps as Array<{ action: string; mcp: string }>) {
       this.mcpByAction.set(step.action, step.mcp);
+      // Plan-binding: record both the action name and the namespaced form
+      this.declaredTools.add(step.action);
+      this.declaredTools.add(`${step.mcp}__${step.action}`);
+    }
+    // Also record the original framework-supplied tool names verbatim
+    for (const tc of toolCalls) {
+      this.declaredTools.add(tc.name);
     }
 
     const planCapture = this.client.capturePlan(this.llm, opts.goal ?? this.llm, plan);
@@ -109,6 +141,112 @@ export class ArmorIQSession {
     this.currentTokenValue = token;
     this.stepIndex = 0;
     return token;
+  }
+
+  /**
+   * Local-mode enforcement.
+   * Verifies the intent token's lifetime, plan-binding, and the
+   * policy snapshot — all in-process. NO network call to the proxy.
+   *
+   * Returns { allowed, action, reason }. Plugin uses this to short-
+   * circuit the framework's tool dispatch on a deny.
+   */
+  async enforceLocal(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+  ): Promise<EnforceResult> {
+    if (!this.currentTokenValue) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: 'No intent token — call startPlan() first',
+      };
+    }
+
+    // 1. Token expiry
+    if (IntentToken.isExpired(this.currentTokenValue)) {
+      return { allowed: false, action: 'block', reason: 'token-expired' };
+    }
+
+    // 2. Plan-binding — tool must have been declared at startPlan() time
+    const { mcp, action } = this.toolNameParser(toolName);
+    const inPlan =
+      this.declaredTools.has(toolName) ||
+      this.declaredTools.has(action) ||
+      this.declaredTools.has(`${mcp}__${action}`);
+    if (!inPlan) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: `tool-not-in-plan: '${toolName}' was not declared in the captured plan`,
+      };
+    }
+
+    // 3. allowed_tools list from the JWT's policy_validation
+    const allowedTools: string[] | undefined =
+      this.currentTokenValue.policyValidation?.allowed_tools;
+    if (Array.isArray(allowedTools) && allowedTools.length > 0) {
+      const wildcard = allowedTools.includes('*');
+      const ok =
+        wildcard ||
+        allowedTools.includes(toolName) ||
+        allowedTools.includes(action);
+      if (!ok) {
+        return {
+          allowed: false,
+          action: 'block',
+          reason: `Tool '${action}' is not in the policy's allowed_tools`,
+          matchedPolicy: this.currentTokenValue.policyValidation?.matched_policies?.[0]?.name,
+        };
+      }
+    }
+
+    // 4. Local policy snapshot evaluation (financial thresholds, etc.)
+    const snapshot = this.currentTokenValue.policySnapshot;
+    if (Array.isArray(snapshot)) {
+      for (const entry of snapshot) {
+        const rules = (entry as any)?.rules ?? entry;
+        const memberRules =
+          rules?.memberRules ?? (rules as any)?.['*'] ?? rules;
+        const allowed: string[] | undefined = memberRules?.allowedTools;
+        if (Array.isArray(allowed) && allowed.length > 0) {
+          const wildcard = allowed.includes('*');
+          const ok = wildcard || allowed.includes(action);
+          if (!ok) {
+            return {
+              allowed: false,
+              action: 'block',
+              reason: `Tool '${action}' not in policy snapshot allowedTools`,
+            };
+          }
+        }
+        // Amount-threshold check
+        const fin = memberRules?.financialRule?.amountThreshold;
+        if (fin && typeof fin === 'object') {
+          for (const [field, threshold] of Object.entries(fin)) {
+            const argVal = Number((toolArgs as any)?.[field]);
+            if (!isNaN(argVal) && argVal > Number(threshold)) {
+              const enforcementAction =
+                memberRules?.enforcementAction ||
+                (entry as any)?.defaultEnforcementAction ||
+                'hold';
+              return {
+                allowed: false,
+                action:
+                  enforcementAction === 'block' ? 'block' : 'hold',
+                reason: `Amount ${argVal} exceeds threshold ${threshold} for field ${field}`,
+              };
+            }
+          }
+        }
+      }
+    }
+
+    return {
+      allowed: true,
+      action: 'allow',
+      reason: 'Allowed by local policy evaluation',
+    };
   }
 
   /**
@@ -129,6 +267,19 @@ export class ArmorIQSession {
 
     const { mcp, action } = this.toolNameParser(toolName);
     const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+
+    // Plan-binding check (cheaper than a network call)
+    const inPlan =
+      this.declaredTools.has(toolName) ||
+      this.declaredTools.has(action) ||
+      this.declaredTools.has(`${resolvedMcp}__${action}`);
+    if (!inPlan) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: `tool-not-in-plan: '${toolName}' was not declared in the captured plan`,
+      };
+    }
 
     try {
       const proxyEndpoint = (this.client as any).defaultProxyEndpoint;
@@ -263,16 +414,35 @@ export class ArmorIQSession {
     return result.result;
   }
 
+  /**
+   * Mode-aware enforcement entry point. Plugins should call this and
+   * not branch themselves — `mode` on the session decides the path.
+   */
+  async check(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+  ): Promise<EnforceResult> {
+    return this.mode === 'proxy'
+      ? this.enforce(toolName, toolArgs)
+      : this.enforceLocal(toolName, toolArgs);
+  }
+
   /** Drop cached plan + token so the next startPlan() always mints fresh. */
   reset(): void {
     this.currentPlanHash = null;
     this.currentTokenValue = null;
     this.mcpByAction.clear();
+    this.declaredTools.clear();
     this.stepIndex = 0;
   }
 
   /** Inspect the currently held intent token (for debugging / audit). */
   get currentToken(): IntentToken | null {
     return this.currentTokenValue;
+  }
+
+  /** Current session mode ('local' default, 'proxy' opt-in). */
+  get currentMode(): SessionMode {
+    return this.mode;
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -599,7 +599,7 @@ export class ArmorIQSession {
   /** Best-effort extraction of an amount field from arbitrary tool args. */
   private extractAmount(args: Record<string, unknown>): number | undefined {
     if (!args || typeof args !== 'object') return undefined;
-    const candidates = ['amount', 'value', 'total', 'price', 'cost'];
+    const candidates = ['amount', 'unit_amount', 'value', 'total', 'price', 'cost'];
     for (const k of candidates) {
       const v = (args as any)[k];
       if (v != null && !isNaN(Number(v))) return Number(v);

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,15 +1,20 @@
 /**
- * ArmorIQSession — collapses the four-step framework-integration
- * pattern into two calls.
+ * ArmorIQSession — the core primitive for framework integrations.
  *
- *   await session.startPlan(toolCalls)        // capture plan + mint token
- *   return session.dispatch(toolName, args)   // route through proxy
+ * Two modes:
  *
- * Each framework adapter (ADK, LangChain, OpenAI Agents, Vercel AI
- * SDK, etc.) wires its own hooks into these two methods and never has
- * to think about plan shape, token threading, or cred-mode handling.
+ * 1. Observe mode (default, new) — MCP stays on the agent side:
+ *      await session.startPlan(toolCalls)                // capture plan + mint token
+ *      const decision = await session.enforce(toolName, toolArgs)  // check policy
+ *      // ... framework calls MCP directly ...
+ *      await session.report(toolName, toolArgs, result)  // audit
+ *
+ * 2. Proxy mode (legacy) — routes through the Armoriq proxy:
+ *      await session.startPlan(toolCalls)
+ *      return session.dispatch(toolName, toolArgs)       // proxy handles everything
  */
 
+import axios from 'axios';
 import { ArmorIQClient } from './client';
 import { IntentToken, MCPInvocationResult, ToolCall } from './models';
 import {
@@ -26,12 +31,30 @@ export interface SessionOptions {
   llm?: string;
 }
 
+export interface EnforceResult {
+  allowed: boolean;
+  action: 'allow' | 'block' | 'hold';
+  reason?: string;
+  delegationId?: string;
+  matchedPolicy?: string;
+}
+
+export interface ReportOptions {
+  status?: 'success' | 'failed' | 'error';
+  errorMessage?: string;
+  durationMs?: number;
+  isDelegated?: boolean;
+  delegatedBy?: string;
+  delegatedTo?: string;
+}
+
 export class ArmorIQSession {
   private client: ArmorIQClient;
   private toolNameParser: ToolNameParser;
   private defaultMcpName?: string;
   private validitySeconds: number;
   private llm: string;
+  private stepIndex: number = 0;
 
   private currentPlanHash: string | null = null;
   private currentTokenValue: IntentToken | null = null;
@@ -70,8 +93,6 @@ export class ArmorIQSession {
       defaultMcpName: this.defaultMcpName,
     });
 
-    // Remember each action's MCP so dispatch() can resolve it without
-    // re-parsing the framework's tool name (which may differ).
     this.mcpByAction.clear();
     for (const step of plan.steps as Array<{ action: string; mcp: string }>) {
       this.mcpByAction.set(step.action, step.mcp);
@@ -86,13 +107,133 @@ export class ArmorIQSession {
 
     this.currentPlanHash = hash;
     this.currentTokenValue = token;
+    this.stepIndex = 0;
     return token;
   }
 
   /**
-   * Route a tool call through the Armoriq proxy.
-   * Returns the raw `result` field so the framework can short-circuit
-   * its native dispatch by returning this value directly.
+   * Check policy for a tool call BEFORE the agent executes it.
+   * Calls POST /iap/enforce on the backend.
+   * Returns { allowed, action, reason }. The framework plugin uses this
+   * to block or let through — the MCP call itself happens on the agent side.
+   */
+  async enforce(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+  ): Promise<EnforceResult> {
+    if (!this.currentTokenValue) {
+      throw new Error(
+        `enforce("${toolName}") called before startPlan().`,
+      );
+    }
+
+    const { mcp, action } = this.toolNameParser(toolName);
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+
+    try {
+      const backendEndpoint = (this.client as any).backendEndpoint;
+      const apiKey = (this.client as any).apiKey;
+
+      const response = await axios.post(
+        `${backendEndpoint}/iap/enforce`,
+        {
+          token: this.currentTokenValue.jwtToken || this.currentTokenValue.tokenId,
+          plan_id: this.currentTokenValue.planId || this.currentTokenValue.tokenId,
+          tool: action,
+          mcp: resolvedMcp,
+          arguments: toolArgs,
+          step_index: this.stepIndex,
+        },
+        {
+          headers: {
+            'X-API-Key': apiKey,
+            'Content-Type': 'application/json',
+          },
+          timeout: 10000,
+        },
+      );
+
+      const data = response.data;
+      return {
+        allowed: data.allowed !== false,
+        action: data.action || (data.allowed === false ? 'block' : 'allow'),
+        reason: data.reason,
+        delegationId: data.delegation_id,
+        matchedPolicy: data.matched_policy,
+      };
+    } catch (err: any) {
+      if (err.response?.status === 403) {
+        const data = err.response.data || {};
+        return {
+          allowed: false,
+          action: data.action || 'block',
+          reason: data.reason || data.message || err.message,
+          matchedPolicy: data.matched_policy,
+        };
+      }
+      // On network error or 5xx, fail open with a warning
+      console.warn(`[ArmorIQ] enforce() failed: ${err.message}. Allowing tool call.`);
+      return { allowed: true, action: 'allow', reason: 'enforce-unavailable' };
+    }
+  }
+
+  /**
+   * Report a tool execution to the audit log AFTER the agent calls the MCP.
+   * Calls POST /iap/audit on the backend.
+   */
+  async report(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+    result: unknown,
+    opts: ReportOptions = {},
+  ): Promise<void> {
+    const { mcp, action } = this.toolNameParser(toolName);
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+
+    try {
+      const backendEndpoint = (this.client as any).backendEndpoint;
+      const apiKey = (this.client as any).apiKey;
+      const token = this.currentTokenValue;
+
+      await axios.post(
+        `${backendEndpoint}/iap/audit`,
+        {
+          token: token?.jwtToken || token?.tokenId || 'unknown',
+          plan_id: token?.planId || token?.tokenId || 'unknown',
+          step_index: this.stepIndex,
+          action,
+          tool: action,
+          mcp: resolvedMcp,
+          input: toolArgs,
+          output: typeof result === 'string' ? { text: result } : (result ?? {}),
+          status: opts.status || 'success',
+          error_message: opts.errorMessage,
+          duration_ms: opts.durationMs,
+          is_delegated: opts.isDelegated,
+          delegated_by: opts.delegatedBy,
+          delegated_to: opts.delegatedTo,
+          executed_at: new Date().toISOString(),
+        },
+        {
+          headers: {
+            'X-API-Key': apiKey,
+            'Content-Type': 'application/json',
+          },
+          timeout: 5000,
+        },
+      );
+    } catch (err: any) {
+      console.warn(`[ArmorIQ] report() failed: ${err.message}`);
+    }
+
+    this.stepIndex++;
+  }
+
+  /**
+   * [Proxy mode] Route a tool call through the Armoriq proxy.
+   * Returns the raw result so the framework can short-circuit
+   * its native dispatch. Use this when the proxy handles the
+   * upstream MCP connection (e.g. Claude Desktop, Cursor).
    */
   async dispatch(
     toolName: string,
@@ -100,15 +241,11 @@ export class ArmorIQSession {
   ): Promise<unknown> {
     if (!this.currentTokenValue) {
       throw new Error(
-        `dispatch("${toolName}") called before startPlan(). ` +
-          'Call startPlan(toolCalls) in your after-model hook first.',
+        `dispatch("${toolName}") called before startPlan().`,
       );
     }
 
     const { mcp, action } = this.toolNameParser(toolName);
-    // Prefer the MCP recorded at plan-capture time when available — this
-    // covers cases where the framework hands us a slightly different
-    // tool name shape than what we parsed off the LLM response.
     const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
 
     const result: MCPInvocationResult = await this.client.invoke(
@@ -117,6 +254,7 @@ export class ArmorIQSession {
       this.currentTokenValue,
       toolArgs,
     );
+    this.stepIndex++;
     return result.result;
   }
 
@@ -125,6 +263,7 @@ export class ArmorIQSession {
     this.currentPlanHash = null;
     this.currentTokenValue = null;
     this.mcpByAction.clear();
+    this.stepIndex = 0;
   }
 
   /** Inspect the currently held intent token (for debugging / audit). */

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,134 @@
+/**
+ * ArmorIQSession — collapses the four-step framework-integration
+ * pattern into two calls.
+ *
+ *   await session.startPlan(toolCalls)        // capture plan + mint token
+ *   return session.dispatch(toolName, args)   // route through proxy
+ *
+ * Each framework adapter (ADK, LangChain, OpenAI Agents, Vercel AI
+ * SDK, etc.) wires its own hooks into these two methods and never has
+ * to think about plan shape, token threading, or cred-mode handling.
+ */
+
+import { ArmorIQClient } from './client';
+import { IntentToken, MCPInvocationResult, ToolCall } from './models';
+import {
+  ToolNameParser,
+  buildPlanFromToolCalls,
+  defaultToolNameParser,
+  hashToolCalls,
+} from './plan-builder';
+
+export interface SessionOptions {
+  toolNameParser?: ToolNameParser;
+  defaultMcpName?: string;
+  validitySeconds?: number;
+  llm?: string;
+}
+
+export class ArmorIQSession {
+  private client: ArmorIQClient;
+  private toolNameParser: ToolNameParser;
+  private defaultMcpName?: string;
+  private validitySeconds: number;
+  private llm: string;
+
+  private currentPlanHash: string | null = null;
+  private currentTokenValue: IntentToken | null = null;
+  private mcpByAction: Map<string, string> = new Map();
+
+  constructor(client: ArmorIQClient, opts: SessionOptions = {}) {
+    this.client = client;
+    this.defaultMcpName = opts.defaultMcpName;
+    this.toolNameParser =
+      opts.toolNameParser ?? defaultToolNameParser(this.defaultMcpName);
+    this.validitySeconds = opts.validitySeconds ?? 3600;
+    this.llm = opts.llm ?? 'agent';
+  }
+
+  /**
+   * Capture a plan from the LLM's tool calls and mint an intent token.
+   * Idempotent: if called again with the same tool-calls list (by SHA),
+   * skips the mint and returns the cached token.
+   */
+  async startPlan(
+    toolCalls: ToolCall[],
+    opts: { goal?: string } = {},
+  ): Promise<IntentToken> {
+    if (toolCalls.length === 0) {
+      throw new Error('startPlan called with no tool calls.');
+    }
+
+    const hash = hashToolCalls(toolCalls);
+    if (this.currentTokenValue && this.currentPlanHash === hash) {
+      return this.currentTokenValue;
+    }
+
+    const plan = buildPlanFromToolCalls(toolCalls, {
+      goal: opts.goal,
+      toolNameParser: this.toolNameParser,
+      defaultMcpName: this.defaultMcpName,
+    });
+
+    // Remember each action's MCP so dispatch() can resolve it without
+    // re-parsing the framework's tool name (which may differ).
+    this.mcpByAction.clear();
+    for (const step of plan.steps as Array<{ action: string; mcp: string }>) {
+      this.mcpByAction.set(step.action, step.mcp);
+    }
+
+    const planCapture = this.client.capturePlan(this.llm, opts.goal ?? this.llm, plan);
+    const token = await this.client.getIntentToken(
+      planCapture,
+      undefined,
+      this.validitySeconds,
+    );
+
+    this.currentPlanHash = hash;
+    this.currentTokenValue = token;
+    return token;
+  }
+
+  /**
+   * Route a tool call through the Armoriq proxy.
+   * Returns the raw `result` field so the framework can short-circuit
+   * its native dispatch by returning this value directly.
+   */
+  async dispatch(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+  ): Promise<unknown> {
+    if (!this.currentTokenValue) {
+      throw new Error(
+        `dispatch("${toolName}") called before startPlan(). ` +
+          'Call startPlan(toolCalls) in your after-model hook first.',
+      );
+    }
+
+    const { mcp, action } = this.toolNameParser(toolName);
+    // Prefer the MCP recorded at plan-capture time when available — this
+    // covers cases where the framework hands us a slightly different
+    // tool name shape than what we parsed off the LLM response.
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+
+    const result: MCPInvocationResult = await this.client.invoke(
+      resolvedMcp,
+      action,
+      this.currentTokenValue,
+      toolArgs,
+    );
+    return result.result;
+  }
+
+  /** Drop cached plan + token so the next startPlan() always mints fresh. */
+  reset(): void {
+    this.currentPlanHash = null;
+    this.currentTokenValue = null;
+    this.mcpByAction.clear();
+  }
+
+  /** Inspect the currently held intent token (for debugging / audit). */
+  get currentToken(): IntentToken | null {
+    return this.currentTokenValue;
+  }
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -183,7 +183,9 @@ export class ArmorIQSession {
     }
 
     const pv = this.currentTokenValue.policyValidation;
-    const matchedPolicyName = pv?.matched_policies?.[0]?.name;
+    const matchedPolicyName =
+      pv?.matched_policies?.[0]?.policyName ||
+      pv?.matched_policies?.[0]?.name;
     const defaultAction =
       pv?.default_enforcement_action ||
       pv?.matched_policies?.[0]?.default_enforcement_action ||

--- a/src/session.ts
+++ b/src/session.ts
@@ -131,18 +131,23 @@ export class ArmorIQSession {
     const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
 
     try {
-      const backendEndpoint = (this.client as any).backendEndpoint;
+      const proxyEndpoint = (this.client as any).defaultProxyEndpoint;
       const apiKey = (this.client as any).apiKey;
 
       const response = await axios.post(
-        `${backendEndpoint}/iap/enforce`,
+        `${proxyEndpoint}/invoke`,
         {
-          token: this.currentTokenValue.jwtToken || this.currentTokenValue.tokenId,
-          plan_id: this.currentTokenValue.planId || this.currentTokenValue.tokenId,
-          tool: action,
+          enforce_only: true,
           mcp: resolvedMcp,
+          tool: action,
+          action,
+          params: toolArgs,
           arguments: toolArgs,
-          step_index: this.stepIndex,
+          intent_token: this.currentTokenValue.rawToken,
+          plan: this.currentTokenValue.rawToken?.plan,
+          ...(this.currentTokenValue.policySnapshot
+            ? { policy_snapshot: this.currentTokenValue.policySnapshot }
+            : {}),
         },
         {
           headers: {

--- a/src/session.ts
+++ b/src/session.ts
@@ -211,11 +211,22 @@ export class ArmorIQSession {
 
     const governingRule = ruleOf(governingEntry);
     const governingPolicyName = governingEntry?.policyName;
-    const governingDefaultAction =
-      governingRule?.enforcementAction ||
+    // For "tool not in allowedTools" we use the POLICY-LEVEL default
+    // (defaultEnforcementAction, defaults to 'block'). The per-rule
+    // enforcementAction is reserved for CONDITIONAL violations like
+    // amount thresholds — a tool that isn't allowed at all can't be
+    // approved through delegation, only blocked.
+    const notAllowedAction =
       governingEntry?.defaultEnforcementAction ||
       pv?.default_enforcement_action ||
       'block';
+    // For threshold violations on an allowed tool, the per-rule action
+    // applies (e.g. 'hold' to require approval for amounts > $50).
+    const conditionalAction =
+      governingRule?.enforcementAction ||
+      governingEntry?.defaultEnforcementAction ||
+      pv?.default_enforcement_action ||
+      'hold';
 
     // 3. denied_tools — explicit deny list from backend evaluation.
     //    Only treat as a deny IF we found a governing policy for this tool.
@@ -234,7 +245,7 @@ export class ArmorIQSession {
             : `Tool '${action}' is denied by policy`);
         return {
           allowed: false,
-          action: governingDefaultAction === 'hold' ? 'hold' : 'block',
+          action: notAllowedAction === 'hold' ? 'hold' : 'block',
           reason,
           matchedPolicy: governingPolicyName,
         };
@@ -255,7 +266,7 @@ export class ArmorIQSession {
         if (!ok) {
           return {
             allowed: false,
-            action: governingDefaultAction === 'hold' ? 'hold' : 'block',
+            action: notAllowedAction === 'hold' ? 'hold' : 'block',
             reason: `Tool '${action}' is not in the allowed tools for policy '${governingPolicyName}'`,
             matchedPolicy: governingPolicyName,
           };
@@ -286,13 +297,9 @@ export class ArmorIQSession {
           if (typeof threshold !== 'number') continue;
           const argVal = Number((toolArgs as any)?.[field]);
           if (!isNaN(argVal) && argVal > Number(threshold)) {
-            const enforcementAction =
-              governingRule.enforcementAction ||
-              governingEntry?.defaultEnforcementAction ||
-              'hold';
             return {
               allowed: false,
-              action: enforcementAction === 'block' ? 'block' : 'hold',
+              action: conditionalAction === 'block' ? 'block' : 'hold',
               reason: `Amount ${argVal} exceeds threshold ${threshold} for field '${field}'`,
               matchedPolicy: governingPolicyName,
             };


### PR DESCRIPTION
## Summary

Three layered changes that ship together as **v0.2.12**:

### 1. Agent-managed upstream MCP credentials
- New `McpCredential` / `McpCredentialMap` types on `SDKConfig`.
- `ArmorIQClient` resolves per-MCP creds from three sources (env JSON, per-MCP env vars, constructor option), constructor highest precedence.
- `invoke()` forwards the cred per-call as a base64-encoded `X-Armoriq-MCP-Auth` header. Proxy strips it before upstream forward.
- Lets users keep upstream MCP secrets out of the Armoriq platform — for client-managed MCPs the platform stores nothing.

### 2. `ArmorIQSession` primitive
- Collapses the 4-step framework-integration pattern (capture plan, mint token, intercept tool, dispatch through proxy) into two calls:
  ```ts
  await session.startPlan(toolCalls)
  return session.dispatch(toolName, toolArgs)
  ```
- Idempotent re-mint by SHA over the tool-calls list.
- `client.startSession(opts)` is the entry point.

### 3. Framework integrations (mirrors Python SDK shape)
- `src/integrations/google-adk.ts` — real, extends ADK `BasePlugin`.
- `src/integrations/crewai.ts` — real, ported from `armoriq_sdk.integrations.crewai`.
- `langchain.ts` / `openai.ts` / `anthropic.ts` — stubs that throw "not yet implemented" with peer-dep install hints (matches Python).
- Each framework lib is an optional `peerDependency`.
- Subpath exports: `@armoriq/sdk-dev/integrations/<name>`.

Vertex AI is covered through the ADK integration (no separate file — same as Python SDK).

## Test plan
- [ ] `npm run build` — passes (verified locally)
- [ ] `node -e "console.log(require('./dist').VERSION)"` → `0.2.12`
- [ ] All 5 integration subpaths import (verified locally)
- [ ] End-to-end tested via the new `sdk-adk-test-agent` (separate repo) in three credential modes (platform / env / constructor)
- [ ] See \`/Users/hariharasudhan/Armoriq/TEST_PLAN_E2E.md\` for the full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)