### PR TITLE
chore: add issue templates and project automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,93 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below to help us identify and fix the issue.
+
+  - type: dropdown
+    id: service
+    attributes:
+      label: Affected Service / Component
+      options:
+        - Backend
+        - Frontend
+        - Proxy Server
+        - SDK (TypeScript)
+        - SDK (Python)
+        - OPA / Policy Engine
+        - CSRG
+        - Agent
+        - Admin Dashboard
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical — service down or data loss
+        - High — major feature broken, no workaround
+        - Medium — feature broken, workaround exists
+        - Low — minor issue, cosmetic
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Production
+        - Staging
+        - Development / Local
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      placeholder: A clear description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Observe error
+
+        Include API request/response, curl commands, or screenshots if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Paste relevant logs, error messages, or attach screenshots.
+      placeholder: Paste logs or drag-and-drop screenshots here.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched for existing issues before creating this one.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/armoriq/.github/security/policy
+    about: Report security vulnerabilities through GitHub's security advisory feature.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,56 @@
+name: Enhancement
+description: Suggest an improvement to an existing feature
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest how we can improve something that already exists.
+
+  - type: dropdown
+    id: service
+    attributes:
+      label: Affected Service / Component
+      options:
+        - Backend
+        - Frontend
+        - Proxy Server
+        - SDK (TypeScript)
+        - SDK (Python)
+        - OPA / Policy Engine
+        - CSRG
+        - Agent
+        - Admin Dashboard
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior
+      placeholder: Describe how the feature currently works.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed improvement
+      placeholder: Describe the change you'd like and why it's better.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      placeholder: Links, screenshots, related issues, or anything else that helps.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched for existing issues before creating this one.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,63 @@
+name: Feature Request
+description: Propose a new feature or capability
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the new feature you'd like to see added.
+
+  - type: dropdown
+    id: service
+    attributes:
+      label: Target Service / Component
+      options:
+        - Backend
+        - Frontend
+        - Proxy Server
+        - SDK (TypeScript)
+        - SDK (Python)
+        - OPA / Policy Engine
+        - CSRG
+        - Agent
+        - Admin Dashboard
+        - Cross-service
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      placeholder: Describe the problem this feature would solve or the use case it enables.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      placeholder: Describe how you think this should work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: Any workarounds or alternative approaches you've considered.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      placeholder: Mockups, references, related issues, or anything else that helps.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched for existing issues before creating this one.
+          required: true

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,15 @@
+name: Auto-add issues to project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/armoriq/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -4,13 +4,16 @@ on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to ArmorIQ project board
+    if: ${{ secrets.ADD_TO_PROJECT_TOKEN != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Add to project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         id: add
         with:
           project-url: https://github.com/orgs/armoriq/projects/1

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -6,10 +6,28 @@ on:
 
 jobs:
   add-to-project:
-    name: Add issue to project
+    name: Add issue to ArmorIQ project board
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - name: Add to project
+        uses: actions/add-to-project@v1.0.2
+        id: add
         with:
           project-url: https://github.com/orgs/armoriq/projects/1
           github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
+
+      - name: Set status to Backlog
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: "PVT_kwDODhptWM4BKTiz"
+                itemId: "'"${{ steps.add.outputs.itemId }}"'"
+                fieldId: "PVTSSF_lADODhptWM4BKTizzg6NlW4"
+                value: { singleSelectOptionId: "f75ad846" }
+              }) {
+                projectV2Item { id }
+              }
+            }'


### PR DESCRIPTION
## Summary
- Adds GitHub issue form templates: **Bug Report**, **Enhancement**, **Feature Request**
- Adds `config.yml` to disable blank issues and link to security advisories
- Adds GitHub Actions workflow to **auto-add new issues** to the [ArmorIQ project board](https://github.com/orgs/armoriq/projects/1) Backlog

## Templates added
| Template | Labels | Purpose |
|----------|--------|---------|
| `bug-report.yml` | `bug` | Structured bug reports with service, severity, environment |
| `enhancement.yml` | `enhancement` | Improvements to existing features |
| `feature-request.yml` | `feature` | New feature proposals with use case and alternatives |

## Automation
The `auto-add-to-project.yml` workflow triggers on every new issue and adds it to the org project board. **Requires** the org-level secret `ADD_TO_PROJECT_TOKEN` (a PAT with `project` scope).

## Test plan
- [ ] Verify templates appear on the "New Issue" page
- [ ] Verify form fields render correctly
- [ ] Verify auto-add workflow runs on issue creation (after secret is configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)