### PR TITLE
chore: bump version to 0.2.14 (published to npm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.2.11",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@armoriq/sdk",
-      "version": "0.2.11",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.2.12",
+  "version": "0.2.14",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `0.2.12` to `0.2.14` to match the npm release.
- `@armoriq/sdk` 0.2.14 is already live on npm: https://www.npmjs.com/package/@armoriq/sdk/v/0.2.14

## Why now
The TS CLI retirement + iap-staging URL work (PR #20) shipped to npm as 0.2.14, but the version field on `main` still reads 0.2.12. This PR realigns the repo metadata with what's published.

## Test plan
- [x] `npm install @armoriq/sdk@0.2.14` installs cleanly from npm
- [x] `npm run build` on `main` is clean — no references to the removed `src/cli/`
- [x] `ArmorIQClient` reads `~/.armoriq/credentials.json` via `src/credentials.ts` fallback (written by Python `armoriq login`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)