### PR TITLE
fix: ARMORIQ_ENV=production on main (was flipped to staging by PR #20 squash)

### DIFF
--- a/src/_build_env.ts
+++ b/src/_build_env.ts
@@ -16,7 +16,7 @@
  * / PROXY_ENDPOINT env vars.
  */
 
-export const ARMORIQ_ENV: 'production' | 'staging' = 'staging';
+export const ARMORIQ_ENV: 'production' | 'staging' = 'production';
 
 // Endpoint table — keep in sync with GCP Cloud Run domain mappings.
 //   prod:


### PR DESCRIPTION
## Summary
- Flips `ARMORIQ_ENV` in `src/_build_env.ts` from `'staging'` back to `'production'` on `main`.

## Why
When PR #20 was squash-merged, GitHub applied dev's net diff onto main without preserving the `ARMORIQ_ENV` conflict resolution. The published `@armoriq/sdk@0.2.14` on npm (https://www.npmjs.com/package/@armoriq/sdk/v/0.2.14) correctly has `ARMORIQ_ENV='production'` baked in — but `origin/main` was left with `'staging'`, so any future publish from main would ship with staging URLs.

Intended invariant: **only `_build_env.ts` differs between `main` (production) and `dev` (staging)**.

## Test plan
- [x] `grep ARMORIQ_ENV src/_build_env.ts` returns `'production'` after the fix
- [x] `git diff main dev -- src/_build_env.ts` shows exactly the single `ARMORIQ_ENV` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)