### PR TITLE
sync: main → dev (pick up sdk prod fix + runtime-override reintroduction)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.2.11",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.0"
+        "axios": "^1.7.0",
+        "commander": "^14.0.3",
+        "open": "^10.2.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
@@ -1918,6 +1920,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2087,6 +2104,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2186,6 +2212,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -3193,6 +3259,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3236,6 +3317,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3264,6 +3363,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4309,6 +4423,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4779,6 +4911,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -5369,6 +5513,21 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.2.11",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@armoriq/sdk",
-      "version": "0.2.11",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.2.12",
+  "version": "0.2.14",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/_build_env.ts
+++ b/src/_build_env.ts
@@ -9,14 +9,15 @@
  *   main branch  →  ARMORIQ_ENV = "production"  (prod URLs; published as stable)
  *   dev  branch  →  ARMORIQ_ENV = "staging"     (staging URLs; published as -dev)
  *
- * The baked constant is the ONLY source of truth — no runtime env-var
- * override. To point the SDK at staging, install the dev build; to
- * override a specific endpoint for testing, pass `backendEndpoint:` etc.
- * to the ArmorIQClient constructor or set BACKEND_ENDPOINT / IAP_ENDPOINT
- * / PROXY_ENDPOINT env vars.
+ * The baked constant is the branch-baked default. Set ARMORIQ_ENV=local
+ * (or staging/production) in your shell to override at runtime. Per-
+ * endpoint env vars (BACKEND_ENDPOINT / IAP_ENDPOINT / PROXY_ENDPOINT)
+ * and constructor args still win over both.
  */
 
-export const ARMORIQ_ENV: 'production' | 'staging' = 'production';
+export type EnvName = 'production' | 'staging' | 'local';
+
+export const ARMORIQ_ENV: EnvName = 'production';
 
 // Endpoint table — keep in sync with GCP Cloud Run domain mappings.
 //   prod:
@@ -27,7 +28,8 @@ export const ARMORIQ_ENV: 'production' | 'staging' = 'production';
 //     staging-api.armoriq.ai          → conmap-auto-staging            (us-central1)
 //     iap-staging.armoriq.ai          → csrg-execution-service-staging (us-central1)
 //     cloud-run-proxy.armoriq.io      → armoriq-proxy-dev              (europe-west1)
-export const ENDPOINTS = {
+//   local: same ports the Python SDK uses.
+export const ENDPOINTS: Record<EnvName, { backend: string; proxy: string; iap: string }> = {
   production: {
     backend: 'https://api.armoriq.ai',
     proxy: 'https://proxy.armoriq.ai',
@@ -38,10 +40,23 @@ export const ENDPOINTS = {
     proxy: 'https://cloud-run-proxy.armoriq.io',
     iap: 'https://iap-staging.armoriq.ai',
   },
-} as const;
+  local: {
+    backend: 'http://127.0.0.1:3000',
+    proxy: 'http://127.0.0.1:3001',
+    iap: 'http://127.0.0.1:8080',
+  },
+};
 
 export type EndpointKind = 'backend' | 'proxy' | 'iap';
 
+function activeEnv(): EnvName {
+  const override = (process.env.ARMORIQ_ENV || '').trim().toLowerCase();
+  if (override === 'production' || override === 'staging' || override === 'local') {
+    return override;
+  }
+  return ARMORIQ_ENV;
+}
+
 export function resolveEndpoint(kind: EndpointKind): string {
-  return ENDPOINTS[ARMORIQ_ENV][kind];
+  return ENDPOINTS[activeEnv()][kind];
 }

--- a/src/_build_env.ts
+++ b/src/_build_env.ts
@@ -1,0 +1,47 @@
+/**
+ * Build-time environment marker (matches armoriq-sdk-customer/_build_env.py).
+ *
+ * This file is the ONLY difference between the `dev` and `main` branches.
+ * Merging dev → main conflicts on the `ARMORIQ_ENV` constant below —
+ * that's intentional, so the release owner consciously flips the default
+ * before publishing prod.
+ *
+ *   main branch  →  ARMORIQ_ENV = "production"  (prod URLs; published as stable)
+ *   dev  branch  →  ARMORIQ_ENV = "staging"     (staging URLs; published as -dev)
+ *
+ * The baked constant is the ONLY source of truth — no runtime env-var
+ * override. To point the SDK at staging, install the dev build; to
+ * override a specific endpoint for testing, pass `backendEndpoint:` etc.
+ * to the ArmorIQClient constructor or set BACKEND_ENDPOINT / IAP_ENDPOINT
+ * / PROXY_ENDPOINT env vars.
+ */
+
+export const ARMORIQ_ENV: 'production' | 'staging' = 'staging';
+
+// Endpoint table — keep in sync with GCP Cloud Run domain mappings.
+//   prod:
+//     api.armoriq.ai    → conmap-auto             (us-central1)
+//     iap.armoriq.ai    → csrg-execution-service  (us-central1)
+//     proxy.armoriq.ai  → armoriq-proxy-server    (us-central1)
+//   staging:
+//     staging-api.armoriq.ai          → conmap-auto-staging            (us-central1)
+//     iap-staging.armoriq.ai          → csrg-execution-service-staging (us-central1)
+//     cloud-run-proxy.armoriq.io      → armoriq-proxy-dev              (europe-west1)
+export const ENDPOINTS = {
+  production: {
+    backend: 'https://api.armoriq.ai',
+    proxy: 'https://proxy.armoriq.ai',
+    iap: 'https://iap.armoriq.ai',
+  },
+  staging: {
+    backend: 'https://staging-api.armoriq.ai',
+    proxy: 'https://cloud-run-proxy.armoriq.io',
+    iap: 'https://iap-staging.armoriq.ai',
+  },
+} as const;
+
+export type EndpointKind = 'backend' | 'proxy' | 'iap';
+
+export function resolveEndpoint(kind: EndpointKind): string {
+  return ENDPOINTS[ARMORIQ_ENV][kind];
+}

--- a/src/_build_env.ts
+++ b/src/_build_env.ts
@@ -16,7 +16,7 @@
  * / PROXY_ENDPOINT env vars.
  */
 
-export const ARMORIQ_ENV: 'production' | 'staging' = 'staging';
+export const ARMORIQ_ENV: 'production' | 'staging' = 'production';
 
 // Endpoint table — keep in sync with GCP Cloud Run domain mappings.
 //   prod:

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,7 +28,7 @@ import {
   PolicyBlockedException,
   PolicyHoldException,
 } from './exceptions';
-import { resolveEndpoint } from './_build_env';
+import { resolveEndpoint, ARMORIQ_ENV } from './_build_env';
 
 /**
  * Main client for ArmorIQ SDK.
@@ -55,10 +55,8 @@ export class ArmorIQClient {
   private static readonly ARMORCLAW_PROXY_ENDPOINT = 'https://customer-proxy.armoriq.ai';
   private static readonly ARMORCLAW_BACKEND_ENDPOINT = 'https://armorclaw-api.armoriq.ai';
 
-  // Local development endpoints - ArmorIQ platform
-  private static readonly LOCAL_IAP_ENDPOINT = 'http://127.0.0.1:8000';
-  private static readonly LOCAL_PROXY_ENDPOINT = 'http://127.0.0.1:3001';
-  private static readonly LOCAL_BACKEND_ENDPOINT = 'http://127.0.0.1:3000';
+  // Local development endpoints for the ArmorIQ platform live in
+  // _build_env.ts under ENDPOINTS.local — resolved via resolveEndpoint().
 
   // Local development endpoints - ArmorClaw standalone
   private static readonly LOCAL_ARMORCLAW_IAP_ENDPOINT = 'http://127.0.0.1:8080';
@@ -81,9 +79,13 @@ export class ArmorIQClient {
   private metadataCache: Map<string, MCPSemanticMetadata>;
 
   constructor(options: Partial<SDKConfig> & { apiKey?: string; useProduction?: boolean } = {}) {
-    // Determine if using production based on environment
-    const envMode = process.env.ARMORIQ_ENV?.toLowerCase() || 'production';
-    const useProd = (options.useProduction ?? true) && envMode === 'production';
+    // `useProduction: false` is a legacy escape hatch for local dev — treat
+    // it as ARMORIQ_ENV=local unless the caller set the env var explicitly.
+    if (options.useProduction === false && !process.env.ARMORIQ_ENV) {
+      process.env.ARMORIQ_ENV = 'local';
+    }
+    const envMode = (process.env.ARMORIQ_ENV || '').toLowerCase();
+    const isLocal = envMode === 'local';
 
     // Resolve API key early to determine product routing
     const resolvedApiKey = options.apiKey || process.env.ARMORIQ_API_KEY || '';
@@ -91,27 +93,29 @@ export class ArmorIQClient {
 
     // Route endpoints based on API key prefix (Stripe pattern)
     // ak_claw_ → ArmorClaw standalone; ak_live_ / ak_test_ → ArmorIQ platform.
-    // For ArmorIQ: production vs staging URLs come from _build_env (branch-baked).
+    // For ArmorIQ: production / staging / local URLs all come from
+    // resolveEndpoint — which reads ARMORIQ_ENV and falls back to the
+    // branch-baked constant in _build_env.ts.
     this.iapEndpoint =
       options.iapEndpoint ||
       process.env.IAP_ENDPOINT ||
       (isArmorClaw
-        ? (useProd ? ArmorIQClient.ARMORCLAW_IAP_ENDPOINT : ArmorIQClient.LOCAL_ARMORCLAW_IAP_ENDPOINT)
-        : (useProd ? resolveEndpoint('iap') : ArmorIQClient.LOCAL_IAP_ENDPOINT));
+        ? (isLocal ? ArmorIQClient.LOCAL_ARMORCLAW_IAP_ENDPOINT : ArmorIQClient.ARMORCLAW_IAP_ENDPOINT)
+        : resolveEndpoint('iap'));
 
     this.defaultProxyEndpoint =
       options.proxyEndpoint ||
       process.env.PROXY_ENDPOINT ||
       (isArmorClaw
-        ? (useProd ? ArmorIQClient.ARMORCLAW_PROXY_ENDPOINT : ArmorIQClient.LOCAL_ARMORCLAW_PROXY_ENDPOINT)
-        : (useProd ? resolveEndpoint('proxy') : ArmorIQClient.LOCAL_PROXY_ENDPOINT));
+        ? (isLocal ? ArmorIQClient.LOCAL_ARMORCLAW_PROXY_ENDPOINT : ArmorIQClient.ARMORCLAW_PROXY_ENDPOINT)
+        : resolveEndpoint('proxy'));
 
     this.backendEndpoint =
       options.backendEndpoint ||
       process.env.BACKEND_ENDPOINT ||
       (isArmorClaw
-        ? (useProd ? ArmorIQClient.ARMORCLAW_BACKEND_ENDPOINT : ArmorIQClient.LOCAL_ARMORCLAW_BACKEND_ENDPOINT)
-        : (useProd ? resolveEndpoint('backend') : ArmorIQClient.LOCAL_BACKEND_ENDPOINT));
+        ? (isLocal ? ArmorIQClient.LOCAL_ARMORCLAW_BACKEND_ENDPOINT : ArmorIQClient.ARMORCLAW_BACKEND_ENDPOINT)
+        : resolveEndpoint('backend'));
 
     // Load user/agent identifiers
     this.userId = options.userId || process.env.USER_ID || '';
@@ -179,8 +183,9 @@ export class ArmorIQClient {
     this.tokenCache = new Map();
     this.metadataCache = new Map();
 
+    const mode = (process.env.ARMORIQ_ENV || '').toLowerCase() || ARMORIQ_ENV;
     console.log(
-      `ArmorIQ SDK initialized: mode=${useProd ? 'production' : 'development'}, ` +
+      `ArmorIQ SDK initialized: mode=${mode}, ` +
         `user=${this.userId}, agent=${this.agentId}, ` +
         `iap=${this.iapEndpoint}, proxy=${this.defaultProxyEndpoint}, ` +
         `backend=${this.backendEndpoint}, ` +

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,6 +28,7 @@ import {
   PolicyBlockedException,
   PolicyHoldException,
 } from './exceptions';
+import { resolveEndpoint } from './_build_env';
 
 /**
  * Main client for ArmorIQ SDK.
@@ -89,40 +90,55 @@ export class ArmorIQClient {
     const isArmorClaw = resolvedApiKey.startsWith('ak_claw_');
 
     // Route endpoints based on API key prefix (Stripe pattern)
-    // ak_claw_ → ArmorClaw standalone, ak_live_ → ArmorIQ platform, ak_test_ → sandbox
+    // ak_claw_ → ArmorClaw standalone; ak_live_ / ak_test_ → ArmorIQ platform.
+    // For ArmorIQ: production vs staging URLs come from _build_env (branch-baked).
     this.iapEndpoint =
       options.iapEndpoint ||
       process.env.IAP_ENDPOINT ||
       (isArmorClaw
         ? (useProd ? ArmorIQClient.ARMORCLAW_IAP_ENDPOINT : ArmorIQClient.LOCAL_ARMORCLAW_IAP_ENDPOINT)
-        : (useProd ? ArmorIQClient.DEFAULT_IAP_ENDPOINT : ArmorIQClient.LOCAL_IAP_ENDPOINT));
+        : (useProd ? resolveEndpoint('iap') : ArmorIQClient.LOCAL_IAP_ENDPOINT));
 
     this.defaultProxyEndpoint =
       options.proxyEndpoint ||
       process.env.PROXY_ENDPOINT ||
       (isArmorClaw
         ? (useProd ? ArmorIQClient.ARMORCLAW_PROXY_ENDPOINT : ArmorIQClient.LOCAL_ARMORCLAW_PROXY_ENDPOINT)
-        : (useProd ? ArmorIQClient.DEFAULT_PROXY_ENDPOINT : ArmorIQClient.LOCAL_PROXY_ENDPOINT));
+        : (useProd ? resolveEndpoint('proxy') : ArmorIQClient.LOCAL_PROXY_ENDPOINT));
 
     this.backendEndpoint =
       options.backendEndpoint ||
       process.env.BACKEND_ENDPOINT ||
       (isArmorClaw
         ? (useProd ? ArmorIQClient.ARMORCLAW_BACKEND_ENDPOINT : ArmorIQClient.LOCAL_ARMORCLAW_BACKEND_ENDPOINT)
-        : (useProd ? ArmorIQClient.DEFAULT_BACKEND_ENDPOINT : ArmorIQClient.LOCAL_BACKEND_ENDPOINT));
+        : (useProd ? resolveEndpoint('backend') : ArmorIQClient.LOCAL_BACKEND_ENDPOINT));
 
     // Load user/agent identifiers
     this.userId = options.userId || process.env.USER_ID || '';
     this.agentId = options.agentId || process.env.AGENT_ID || '';
     this.contextId = options.contextId || process.env.CONTEXT_ID || 'default';
+    // API key resolution order: explicit param → env var → credentials file → empty
     this.apiKey = options.apiKey || process.env.ARMORIQ_API_KEY || '';
+    if (!this.apiKey) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { loadCredentials } = require('./credentials');
+        const creds = loadCredentials();
+        if (creds?.apiKey) {
+          this.apiKey = creds.apiKey;
+        }
+      } catch {
+        // credentials module not available (e.g. bundled build) — ignore
+      }
+    }
 
     // Validate required config
     if (!this.apiKey) {
       throw new ConfigurationException(
         'API key is required for Customer SDK. ' +
-          'Set ARMORIQ_API_KEY environment variable or pass apiKey parameter. ' +
-          'Get your API key from https://platform.armoriq.ai/dashboard/api-keys'
+          'Install the ArmorIQ CLI (`pip install armoriq-sdk`) and run `armoriq login` to authenticate, ' +
+          'or set ARMORIQ_API_KEY, or pass apiKey parameter. ' +
+          'Get your API key from https://dev.armoriq.ai'
       );
     }
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const ARMORIQ_DIR = path.join(os.homedir(), '.armoriq');
+const CREDENTIALS_FILE = path.join(ARMORIQ_DIR, 'credentials.json');
+
+export interface Credentials {
+  apiKey: string;
+  email: string;
+  userId: string;
+  orgId: string;
+  savedAt: string;
+}
+
+export function loadCredentials(): Credentials | null {
+  try {
+    if (!fs.existsSync(CREDENTIALS_FILE)) {
+      return null;
+    }
+    const raw = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.apiKey === 'string' && parsed.apiKey.startsWith('ak_')) {
+      return parsed as Credentials;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCredentials(creds: Credentials): void {
+  fs.mkdirSync(ARMORIQ_DIR, { recursive: true });
+  const content = JSON.stringify(creds, null, 2) + '\n';
+  fs.writeFileSync(CREDENTIALS_FILE, content, { mode: 0o600 });
+}
+
+export function clearCredentials(): boolean {
+  try {
+    if (fs.existsSync(CREDENTIALS_FILE)) {
+      fs.unlinkSync(CREDENTIALS_FILE);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function getCredentialsPath(): string {
+  return CREDENTIALS_FILE;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "node16",
     "lib": ["ES2022"],
     "declaration": true,
     "declarationMap": true,
@@ -13,7 +13,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "types": ["node"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary

Brings recent main-only commits back to dev so the two branches stay aligned (only `_build_env.ts`'s `ARMORIQ_ENV` constant should differ).

### What's coming in
- `#22` ARMORIQ_ENV flip back to production on main (dev keeps \"staging\" — expected conflict on merge)
- `#24` ARMORIQ_ENV=local runtime override + local endpoint row
- Other main squash-merges not yet in dev: `#21` (0.2.14 npm release), `#20` (TS CLI retirement, iap-staging URL), `#18` etc.

## Post-merge

- [ ] Ensure `_build_env.ts` on dev keeps `ARMORIQ_ENV = 'staging'` (intentional divergence — resolve the conflict by picking dev's \"staging\")
- [ ] Ensure `package.json` on dev keeps `"name": "@armoriq/sdk-dev"` (intentional divergence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)