### PR TITLE
bump version to 0.2.15 for republish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Why

Published \`@armoriq/sdk 0.2.14\` is missing the content from #24 (runtime override + local endpoint row + \`tsconfig.json\` node16). Bumping so we can publish an \`@armoriq/sdk 0.2.15\` that matches what's on main.

## Next steps after merge
- \`gh workflow run release.yml --ref main\` → publishes \`@armoriq/sdk 0.2.15\`