### PR TITLE
bump version to 0.2.15 for republish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Why

Published \`@armoriq/sdk-dev 0.2.14\` is missing the content from sync #26 (runtime override + local row + \`tsconfig.json\` node16). Bumping so we can publish \`@armoriq/sdk-dev 0.2.15\` matching what's on dev.

## Next steps after merge
- \`gh workflow run release.yml --ref dev\` → publishes \`@armoriq/sdk-dev 0.2.15\`