### PR TITLE
bump version to 0.2.15 for republish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Publishes what's already on dev: #24 (sdk prod fix — local-mode runtime override), #26 (main→dev sync), and #23 (Idempotency-Key + policy_validation forwarding). The package was still tagged \`0.2.14\` despite having all that content on top.

## No port from Python #18

Spent time investigating whether hold auto-retry from [Hari's Python #18](https://github.com/armoriq/armoriq-sdk-customer/pull/18) needed porting here — conclusion: **no**. TS already has it, and it's more robust:

| | Python (google_adk) | TS (invokeWithPolicy) |
|---|---|---|
| Timeout | 60s fixed (20 × 3s) | 30min default, configurable via \`delegationTimeoutMs\` |
| Backoff | Flat 3s | Exponential 3s → 15s |
| Location | Integration layer | SDK layer |

TS also doesn't have \`session.enforce()\` or Python's separate \`/enforce\` endpoint flow, so the \`enforcementAction\` / \`matchedPolicy\` dict-normalization parts of Hari's PR don't apply (different schema — TS reads \`responseData.enforcement.action\` inline).

Updating armoriq-sdk-customer-ts#27 to close with this finding.

## Test plan
- [x] \`npm run build\` — clean
- [ ] After merge + publish: \`npm view @armoriq/sdk-dev version\` → \`0.2.15\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)