### PR TITLE
port: matchedPolicy normalization from Python #18 (defensive parsing)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -39,6 +39,12 @@ import { resolveEndpoint, ARMORIQ_ENV } from './_build_env';
  * - MCP action invocation
  * - Agent delegation
  */
+function normalizeMatchedPolicy(raw: any): string | undefined {
+  const v = raw?.matched_policy ?? raw?.matchedPolicy;
+  if (!v) return undefined;
+  return typeof v === 'object' ? v.name : v;
+}
+
 export class ArmorIQClient {
   // Production endpoints (default) - ArmorIQ platform
   private static readonly DEFAULT_IAP_ENDPOINT = 'https://iap.armoriq.ai';
@@ -1025,6 +1031,7 @@ export class ArmorIQClient {
           enforcement.action,
           enforcement.reason,
           enforcement.metadata,
+          normalizeMatchedPolicy(enforcement),
         );
       }
 
@@ -1044,6 +1051,7 @@ export class ArmorIQClient {
             responseData.message || 'Action held for approval',
             responseData.delegation_context,
             enforcement.metadata,
+            normalizeMatchedPolicy(enforcement),
           );
         }
 
@@ -1086,6 +1094,7 @@ export class ArmorIQClient {
             responseData.message || 'Action held for approval (delegation request failed)',
             responseData.delegation_context,
             { ...enforcement.metadata, delegationError: delegationError.message },
+            normalizeMatchedPolicy(enforcement),
           );
         }
 

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -128,18 +128,21 @@ export class PolicyBlockedException extends ArmorIQException {
   public enforcementAction?: string;
   public reason?: string;
   public metadata?: Record<string, any>;
+  public matchedPolicy?: string;
 
   constructor(
     message: string,
     enforcementAction?: string,
     reason?: string,
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    matchedPolicy?: string
   ) {
     super(message);
     this.name = 'PolicyBlockedException';
     this.enforcementAction = enforcementAction;
     this.reason = reason;
     this.metadata = metadata;
+    this.matchedPolicy = matchedPolicy;
     Object.setPrototypeOf(this, PolicyBlockedException.prototype);
   }
 }
@@ -150,16 +153,19 @@ export class PolicyBlockedException extends ArmorIQException {
 export class PolicyHoldException extends ArmorIQException {
   public delegationContext?: Record<string, any>;
   public metadata?: Record<string, any>;
+  public matchedPolicy?: string;
 
   constructor(
     message: string,
     delegationContext?: Record<string, any>,
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    matchedPolicy?: string
   ) {
     super(message);
     this.name = 'PolicyHoldException';
     this.delegationContext = delegationContext;
     this.metadata = metadata;
+    this.matchedPolicy = matchedPolicy;
     Object.setPrototypeOf(this, PolicyHoldException.prototype);
   }
 }


### PR DESCRIPTION
## Summary

Mirrors the \`matched_policy\` defensive-parsing fix Hari added to Python in [armoriq-sdk-customer#18](https://github.com/armoriq/armoriq-sdk-customer/pull/18) (session.py:392-393). The backend can return the matched policy as any of:

| Backend shape | Normalized to |
|---|---|
| \`\"matched_policy\": \"admin-only-policy\"\` (snake_case string) | \`\"admin-only-policy\"\` |
| \`\"matchedPolicy\": \"admin-only-policy\"\` (camelCase string) | \`\"admin-only-policy\"\` |
| \`\"matchedPolicy\": { \"name\": \"admin-only-policy\", \"id\": \"pol_123\", ... }\` (dict) | \`\"admin-only-policy\"\` |
| missing | \`undefined\` |

Without this, f-string interpolation (\`\`\`\`Blocked by policy: \${err.matchedPolicy}\`\`\`\`) would show \`[object Object]\` when the backend returned the dict shape.

## Changes

- [src/exceptions.ts](src/exceptions.ts) — \`matchedPolicy?: string\` added to \`PolicyBlockedException\` (5th positional arg) and \`PolicyHoldException\` (4th positional arg). Non-breaking — existing callers get \`undefined\`.
- [src/client.ts](src/client.ts) — new \`normalizeMatchedPolicy\` helper at file top; wired into all three throw sites in \`invokeWithPolicy\`'s catch branch.

## What's NOT ported from Python #18

- **\`enforcementAction\` parsing** — Python's fix was in \`session.py::enforce()\` which hits a separate \`/iap/enforce\` endpoint. TS has no session-level enforce call; enforcement comes inline on \`/invoke\` via \`responseData.enforcement.action\` (different schema, doesn't need \`enforcementAction\` fallback).
- **Hold auto-retry** — TS already had this in \`invokeWithPolicy\` (30min + exponential 3s→15s), actually more robust than Python's original 60s flat loop. Python's \`google_adk\` integration loop was upgraded to match in [armoriq-sdk-customer#23](https://github.com/armoriq/armoriq-sdk-customer/pull/23).

## Closes
- armoriq-sdk-customer-ts#27

## Test plan
- [x] \`npm run build\` — clean
- [ ] No behavior change when backend returns string matchedPolicy (existing callers unaffected)
- [ ] When backend returns \`{ name: ... }\` dict, \`err.matchedPolicy\` is the name string, not \`[object Object]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)