### PR TITLE
sync: main → dev (full parity port: sessions, CLI, ADK, etc.)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  testMatch: ['**/?(*.)+(test|spec).ts'],
+  moduleFileExtensions: ['ts', 'js'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.test.json',
+        diagnostics: { ignoreCodes: [151002] },
+      },
+    ],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@armoriq/sdk",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "license": "MIT",
       "dependencies": {
+        "@types/js-yaml": "^4.0.9",
         "axios": "^1.7.0",
-        "commander": "^14.0.3",
-        "open": "^10.2.0"
+        "js-yaml": "^4.1.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
@@ -1310,6 +1310,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
@@ -1657,7 +1663,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -1920,21 +1925,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2104,15 +2094,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2212,46 +2193,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -3259,21 +3200,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3317,24 +3243,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3363,21 +3271,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4055,7 +3948,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4418,24 +4310,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4911,18 +4785,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -5513,21 +5375,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
-  "name": "@armoriq/sdk-dev",
+  "name": "@armoriq/sdk",
   "version": "0.2.15",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "armoriq": "dist/cli/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "jest",
+    "test:unit": "jest --testPathIgnorePatterns=/tests/e2e/",
+    "test:e2e": "jest tests/e2e",
     "lint": "eslint 'src/**/*.ts'",
     "format": "prettier --write \"src/**/*.ts\"",
     "prepublishOnly": "npm run build"
@@ -38,10 +43,12 @@
     "LICENSE"
   ],
   "dependencies": {
-    "axios": "^1.7.0"
+    "axios": "^1.7.0",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,0 +1,255 @@
+/**
+ * armoriq login / logout / whoami — OAuth 2.0 device-code flow (RFC 8628).
+ * Mirrors armoriq_sdk/cli_auth.py.
+ *
+ * The browser approval page either redirects straight back to our
+ * local callback with the key, or — if the callback can't be reached —
+ * we fall back to polling /auth/device/token.
+ */
+
+import * as http from 'http';
+import * as net from 'net';
+import { URL } from 'url';
+import { exec } from 'child_process';
+import axios from 'axios';
+import {
+  Credentials,
+  saveCredentials,
+  loadCredentials,
+  clearCredentials,
+  getCredentialsPath,
+} from '../../credentials';
+import { CHECK, CROSS, WARN, CLIError, out, backendBase } from '../util';
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>ArmorIQ</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+         display: flex; align-items: center; justify-content: center; height: 100vh;
+         margin: 0; background: #f8fafc; color: #1e293b; }
+  .card { text-align: center; padding: 3rem; background: white;
+          border-radius: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+          max-width: 400px; }
+  .check { width: 64px; height: 64px; background: #dcfce7; border-radius: 50%;
+           display: flex; align-items: center; justify-content: center;
+           margin: 0 auto 1.5rem; }
+  .check svg { width: 32px; height: 32px; color: #16a34a; }
+  h2 { margin: 0 0 0.5rem; font-size: 1.25rem; }
+  p { margin: 0; font-size: 0.875rem; color: #64748b; }
+</style></head><body>
+<div class="card">
+  <div class="check">
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+    </svg>
+  </div>
+  <h2>Authorized</h2>
+  <p>You can close this tab and return to your terminal.</p>
+</div>
+</body></html>`;
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (addr && typeof addr === 'object') {
+        const port = addr.port;
+        server.close(() => resolve(port));
+      } else {
+        reject(new Error('Could not get free port'));
+      }
+    });
+  });
+}
+
+interface CallbackResult {
+  api_key?: string;
+  email?: string;
+  user_id?: string;
+  org_id?: string;
+}
+
+function startCallbackServer(
+  port: number,
+): { server: http.Server; once: Promise<CallbackResult> } {
+  let resolveResult: (r: CallbackResult) => void;
+  const once = new Promise<CallbackResult>((resolve) => {
+    resolveResult = resolve;
+  });
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+    if (url.pathname === '/callback') {
+      const params = Object.fromEntries(url.searchParams.entries());
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(SUCCESS_HTML);
+      const result: CallbackResult = {
+        api_key: params.key,
+        email: params.email,
+        user_id: params.user_id,
+        org_id: params.org_id,
+      };
+      if (result.api_key) resolveResult(result);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  server.listen(port, '127.0.0.1');
+  return { server, once };
+}
+
+function openBrowser(url: string): void {
+  const cmd =
+    process.platform === 'darwin'
+      ? `open "${url}"`
+      : process.platform === 'win32'
+        ? `start "" "${url}"`
+        : `xdg-open "${url}"`;
+  exec(cmd, () => {
+    /* best-effort */
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export async function cmdLogin(args: { backend?: string; org?: string }): Promise<number> {
+  const backend = (args.backend ?? process.env.ARMORIQ_BACKEND_URL ?? backendBase()).replace(
+    /\/+$/,
+    '',
+  );
+  const requestedOrg = (args.org ?? '').trim();
+
+  out('');
+  out('  \x1b[1m\x1b[36m┃ ArmorIQ Login\x1b[0m');
+  out('');
+
+  const port = await findFreePort();
+  const callbackUrl = `http://localhost:${port}/callback`;
+  const { server, once: callbackOnce } = startCallbackServer(port);
+
+  let dc: any;
+  try {
+    const r = await axios.post(`${backend}/auth/device/code`, { callback_url: callbackUrl }, { timeout: 10000 });
+    dc = r.data;
+  } catch (e) {
+    server.close();
+    out(`  ${CROSS} Failed to request device code: ${(e as Error).message}`);
+    return 1;
+  }
+
+  const { device_code, user_code, verification_uri_complete } = dc;
+  const interval = Number(dc.interval ?? 5) || 5;
+  const expiresIn = Number(dc.expires_in ?? 600) || 600;
+
+  const sep = verification_uri_complete.includes('?') ? '&' : '?';
+  let browserUrl =
+    `${verification_uri_complete}${sep}callback=${encodeURIComponent(callbackUrl)}`;
+  if (requestedOrg) browserUrl += `&org=${encodeURIComponent(requestedOrg)}`;
+
+  out('  Opening browser...\n');
+  openBrowser(browserUrl);
+  out('  If the browser didn\'t open, visit:');
+  out(`    \x1b[36m\x1b[1m${browserUrl}\x1b[0m\n`);
+  out(`  Confirm this code in your browser: \x1b[1m${user_code}\x1b[0m\n`);
+  process.stdout.write('  Waiting for authorization...');
+
+  const deadline = Date.now() + expiresIn * 1000;
+  let result: CallbackResult | undefined;
+  let lastErr: string | undefined;
+
+  while (Date.now() < deadline && !result) {
+    // Race callback vs poll; whichever resolves first wins.
+    const callbackOrTimeout = Promise.race([
+      callbackOnce.then((r) => ({ kind: 'cb', value: r }) as const),
+      sleep(interval * 1000).then(() => ({ kind: 'tick' }) as const),
+    ]);
+    const tick = await callbackOrTimeout;
+    if (tick.kind === 'cb' && tick.value.api_key) {
+      result = tick.value;
+      break;
+    }
+    try {
+      const pr = await axios.post(
+        `${backend}/auth/device/token`,
+        { deviceCode: device_code },
+        { timeout: 10000, validateStatus: () => true },
+      );
+      const data = pr.data ?? {};
+      const err = data.error;
+      if (err === 'authorization_pending' || err === 'slow_down') continue;
+      if (err) {
+        lastErr = data.error_description || err;
+        break;
+      }
+      if (data.api_key) {
+        result = {
+          api_key: data.api_key,
+          email: data.email,
+          user_id: data.user_id,
+          org_id: data.org_id,
+        };
+        break;
+      }
+    } catch {
+      // network blip; keep polling
+    }
+  }
+
+  server.close();
+
+  if (!result || !result.api_key) {
+    out(` ${CROSS}`);
+    out(`  ${CROSS} ${lastErr ?? 'Timed out waiting for authorization. Run `armoriq login` again.'}`);
+    return 1;
+  }
+
+  saveCredentials({
+    apiKey: result.api_key,
+    email: result.email ?? '',
+    userId: result.user_id ?? '',
+    orgId: result.org_id ?? '',
+    savedAt: new Date().toISOString(),
+  });
+  out(` ${CHECK}`);
+  out('');
+  out(
+    `  ${CHECK} Logged in as \x1b[1m${result.email ?? 'unknown'}\x1b[0m (org: ${result.org_id ?? 'unknown'})`,
+  );
+  out(`  ${CHECK} API key saved to ${getCredentialsPath()}`);
+  out('');
+  return 0;
+}
+
+export function cmdLogout(): number {
+  if (clearCredentials()) {
+    out(`  ${CHECK} Credentials removed from ${getCredentialsPath()}`);
+  } else {
+    out('  \x1b[2mNo credentials found — already logged out.\x1b[0m');
+  }
+  return 0;
+}
+
+export function cmdWhoami(): number {
+  const creds = loadCredentials();
+  if (!creds) {
+    out('  \x1b[2mNot logged in. Run `armoriq login` to authenticate.\x1b[0m');
+    return 0;
+  }
+  out('');
+  out('  \x1b[1m\x1b[36m┃ ArmorIQ Credentials\x1b[0m');
+  out('');
+  const keyPreview = creds.apiKey.length > 16 ? creds.apiKey.slice(0, 16) + '...' : creds.apiKey;
+  out(`  Email:    \x1b[1m${creds.email || 'unknown'}\x1b[0m`);
+  out(`  API Key:  \x1b[2m${keyPreview}\x1b[0m`);
+  out(`  User ID:  \x1b[2m${creds.userId || 'n/a'}\x1b[0m`);
+  out(`  Org ID:   \x1b[2m${creds.orgId || 'n/a'}\x1b[0m`);
+  out(`  Saved at: \x1b[2m${creds.savedAt || 'n/a'}\x1b[0m`);
+  out(`  File:     \x1b[2m${getCredentialsPath()}\x1b[0m`);
+  out('');
+  return 0;
+}

--- a/src/cli/commands/keys.ts
+++ b/src/cli/commands/keys.ts
@@ -1,0 +1,136 @@
+/**
+ * armoriq keys list / revoke / prune — API key management.
+ * Mirrors PR #24 (TS) by symmetry; backend routes already exist:
+ *   GET /api-keys                  (JwtAuthGuard — uses credentials JWT)
+ *   POST /api-keys/:id/revoke      (JwtAuthGuard)
+ */
+
+import axios from 'axios';
+import { CHECK, CLIError, backendBase, out, requireCredentials } from '../util';
+import { appendLog } from '../state';
+
+const KEY_COUNT_WARN_THRESHOLD = 8;
+
+interface ApiKey {
+  id: string;
+  name?: string;
+  prefix?: string;
+  status?: string;
+  createdAt?: string;
+  lastUsedAt?: string;
+  expiresAt?: string;
+  revokedAt?: string;
+}
+
+async function listKeys(apiKey: string): Promise<ApiKey[]> {
+  const url = `${backendBase()}/api-keys`;
+  const response = await axios.get(url, {
+    headers: { 'X-API-Key': apiKey },
+    timeout: 12000,
+    validateStatus: () => true,
+  });
+  if (response.status === 401) throw new CLIError('API key rejected (401). Try `armoriq login` again.');
+  if (response.status >= 400) throw new CLIError(`Failed to list keys (HTTP ${response.status}).`);
+  const data = response.data;
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.data)) return data.data;
+  return [];
+}
+
+async function revokeKey(apiKey: string, keyId: string): Promise<void> {
+  const url = `${backendBase()}/api-keys/${keyId}/revoke`;
+  const response = await axios.post(url, {}, {
+    headers: { 'X-API-Key': apiKey, 'Content-Type': 'application/json' },
+    timeout: 12000,
+    validateStatus: () => true,
+  });
+  if (response.status === 401) throw new CLIError('API key rejected (401). Try `armoriq login` again.');
+  if (response.status >= 400) {
+    throw new CLIError(
+      `Failed to revoke key ${keyId} (HTTP ${response.status}): ${response.data?.message ?? ''}`,
+    );
+  }
+}
+
+export async function cmdKeysList(): Promise<number> {
+  const creds = requireCredentials();
+  const keys = await listKeys(creds.apiKey);
+  if (keys.length === 0) {
+    out('No API keys found for this account.');
+    return 0;
+  }
+  const nameW = Math.max('NAME'.length, ...keys.map((k) => (k.name ?? '').length));
+  const idW = Math.max('ID'.length, ...keys.map((k) => k.id.length));
+  out(`  ${'NAME'.padEnd(nameW)}  ${'ID'.padEnd(idW)}  STATUS    LAST USED`);
+  out('  ' + '-'.repeat(nameW + idW + 30));
+  for (const k of keys) {
+    const name = (k.name ?? '').padEnd(nameW);
+    const id = k.id.padEnd(idW);
+    const status = (k.status ?? 'unknown').padEnd(8);
+    const last = k.lastUsedAt ?? '-';
+    out(`  ${name}  ${id}  ${status}  ${last}`);
+  }
+  out('');
+  if (keys.length > KEY_COUNT_WARN_THRESHOLD) {
+    out(
+      `\x1b[33m!\x1b[0m You have ${keys.length} API keys. Consider \`armoriq keys prune\` to revoke unused keys.`,
+    );
+  }
+  appendLog('keys-list', { count: keys.length });
+  return 0;
+}
+
+export async function cmdKeysRevoke(args: { id: string }): Promise<number> {
+  if (!args.id) throw new CLIError('Key id is required: `armoriq keys revoke <id>`.');
+  const creds = requireCredentials();
+  await revokeKey(creds.apiKey, args.id);
+  out(`${CHECK} Revoked key ${args.id}.`);
+  appendLog('keys-revoke', { id: args.id });
+  return 0;
+}
+
+export async function cmdKeysPrune(args: { yes?: boolean }): Promise<number> {
+  const creds = requireCredentials();
+  const keys = await listKeys(creds.apiKey);
+
+  const now = Date.now();
+  const candidates = keys.filter((k) => {
+    if (k.status && k.status.toLowerCase() === 'revoked') return false;
+    if (k.id === creds.apiKey) return false;
+    if (k.expiresAt && new Date(k.expiresAt).getTime() < now) return true;
+    if (k.lastUsedAt) {
+      const ageDays = (now - new Date(k.lastUsedAt).getTime()) / 86400000;
+      if (ageDays > 90) return true;
+    }
+    if (!k.lastUsedAt && k.createdAt) {
+      const ageDays = (now - new Date(k.createdAt).getTime()) / 86400000;
+      if (ageDays > 30) return true;
+    }
+    return false;
+  });
+
+  if (candidates.length === 0) {
+    out('Nothing to prune — all keys are either active, recent, or already revoked.');
+    return 0;
+  }
+
+  out(`Found ${candidates.length} prune candidate(s):`);
+  for (const k of candidates) {
+    out(`  ${k.id} ${k.name ?? ''} (last used ${k.lastUsedAt ?? 'never'})`);
+  }
+  if (!args.yes) {
+    out('');
+    out('Re-run with --yes to actually revoke these.');
+    return 0;
+  }
+  for (const k of candidates) {
+    try {
+      await revokeKey(creds.apiKey, k.id);
+      out(`${CHECK} Revoked ${k.id}`);
+    } catch (e) {
+      out(`\x1b[31m✘\x1b[0m Failed to revoke ${k.id}: ${(e as Error).message}`);
+    }
+  }
+  appendLog('keys-prune', { revoked: candidates.length });
+  return 0;
+}

--- a/src/cli/commands/orgs.ts
+++ b/src/cli/commands/orgs.ts
@@ -1,0 +1,113 @@
+/**
+ * armoriq orgs / switch-org — list and switch ArmorIQ organizations.
+ * Mirrors armoriq_sdk/cli.py:cmd_orgs / cmd_switch_org.
+ */
+
+import axios from 'axios';
+import { saveCredentials } from '../../credentials';
+import { CHECK, CLIError, backendBase, out, requireCredentials } from '../util';
+import { appendLog, clearState, STATE_FILE } from '../state';
+import * as fs from 'fs';
+
+export async function cmdOrgs(): Promise<number> {
+  const creds = requireCredentials();
+  const url = `${backendBase()}/iap/sdk/orgs`;
+  let response;
+  try {
+    response = await axios.get(url, {
+      headers: { 'X-API-Key': creds.apiKey },
+      timeout: 12000,
+      validateStatus: () => true,
+    });
+  } catch (e) {
+    throw new CLIError(`Failed to reach ${url}: ${(e as Error).message}`);
+  }
+  if (response.status === 401) {
+    throw new CLIError('API key rejected (401). Try `armoriq login` again.');
+  }
+  if (response.status >= 400) {
+    throw new CLIError(`Failed to list orgs (HTTP ${response.status}).`);
+  }
+  const orgs: any[] = response.data?.data ?? [];
+  if (orgs.length === 0) {
+    out("You don't belong to any organizations.");
+    return 0;
+  }
+
+  const nameW = Math.max('NAME'.length, ...orgs.map((o) => (o.name ?? '').length));
+  const roleW = Math.max('ROLE'.length, ...orgs.map((o) => (o.userRole ?? '').length));
+  const header = `  ${'NAME'.padEnd(nameW)}  ${'ORG_ID'.padEnd(36)}  ${'ROLE'.padEnd(roleW)}  MEMBERS`;
+  out(header);
+  out('  ' + '-'.repeat(header.length - 2));
+  for (const org of orgs) {
+    const marker = org.active ? `${CHECK} ` : '  ';
+    const name = (org.name ?? '').padEnd(nameW);
+    const orgId = (org.orgId ?? '').padEnd(36);
+    const role = (org.userRole ?? '').padEnd(roleW);
+    const members = String(org.memberCount ?? 0);
+    out(`${marker}${name}  ${orgId}  ${role}  ${members}`);
+  }
+  out('');
+  out(`Active org is marked with ${CHECK}. Switch with \`armoriq switch-org <name-or-id>\`.`);
+  appendLog('orgs', { count: orgs.length });
+  return 0;
+}
+
+export async function cmdSwitchOrg(args: { org: string; keyName?: string }): Promise<number> {
+  const creds = requireCredentials();
+  const target = (args.org ?? '').trim();
+  if (!target) throw new CLIError('Target org (id or name) is required.');
+
+  const url = `${backendBase()}/iap/sdk/switch-org`;
+  const body: Record<string, unknown> = { org: target };
+  if (args.keyName) body.keyName = args.keyName;
+
+  let response;
+  try {
+    response = await axios.post(url, body, {
+      headers: { 'X-API-Key': creds.apiKey, 'Content-Type': 'application/json' },
+      timeout: 12000,
+      validateStatus: () => true,
+    });
+  } catch (e) {
+    throw new CLIError(`Failed to reach ${url}: ${(e as Error).message}`);
+  }
+  if (response.status === 401) throw new CLIError('API key rejected (401). Try `armoriq login` again.');
+  if (response.status === 403) throw new CLIError(`You are not a member of '${target}'.`);
+  if (response.status === 404) throw new CLIError(`No organization named '${target}' (or matching that id).`);
+  if (response.status === 400) {
+    throw new CLIError(response.data?.message || 'Bad request.');
+  }
+  if (response.status >= 400) {
+    throw new CLIError(`Switch failed (HTTP ${response.status}).`);
+  }
+
+  const payload = response.data ?? {};
+  const newApiKey: string | undefined = payload.api_key;
+  const newOrgId: string | undefined = payload.org_id;
+  const newOrgName: string = payload.org_name ?? target;
+  if (!newApiKey || !newOrgId) {
+    throw new CLIError('Switch response missing api_key or org_id.');
+  }
+
+  saveCredentials({
+    apiKey: newApiKey,
+    email: creds.email,
+    userId: creds.userId,
+    orgId: newOrgId,
+    savedAt: new Date().toISOString(),
+  });
+
+  // Agent registration (state.json) was org-scoped — invalidate it so the
+  // next step is obvious.
+  const stateExisted = fs.existsSync(STATE_FILE);
+  if (stateExisted) clearState();
+
+  out(`${CHECK} Switched to ${newOrgName} (org_id=${newOrgId})`);
+  out(`${CHECK} New API key saved.`);
+  if (stateExisted) {
+    out('  Previous agent registration cleared. Re-run `armoriq register` in this org.');
+  }
+  appendLog('switch-org', { org_id: newOrgId, org_name: newOrgName, cleared_state: stateExisted });
+  return 0;
+}

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,0 +1,64 @@
+/**
+ * armoriq status / logs — local-only commands that read the cached state
+ * and CLI log file. Mirrors armoriq_sdk/cli.py:cmd_status / cmd_logs.
+ */
+
+import * as fs from 'fs';
+import { out } from '../util';
+import { LOG_FILE, loadState } from '../state';
+
+export function cmdStatus(): number {
+  const state = loadState();
+  if (!state || Object.keys(state).length === 0) {
+    out('No local registration state found. Run `armoriq register` first.');
+    return 1;
+  }
+  out(`Agent: ${state.agent_id ?? 'unknown'}`);
+  out(`User: ${state.user_id ?? 'unknown'}`);
+  out(`Environment: ${state.environment ?? 'unknown'}`);
+  out(`Registered at: ${state.registered_at ?? 'unknown'}`);
+  out(`Proxy endpoint: ${state.proxy_endpoint ?? 'unknown'}`);
+  const mcpServers = state.mcp_servers ?? [];
+  out(`MCP servers: ${mcpServers.length > 0 ? mcpServers.join(', ') : '(none)'}`);
+  return 0;
+}
+
+export function cmdLogs(args: { follow?: boolean }): number {
+  if (!fs.existsSync(LOG_FILE)) {
+    out('No CLI logs found yet.');
+    return 0;
+  }
+  const tailFile = (offset: number): number => {
+    const stat = fs.statSync(LOG_FILE);
+    if (stat.size <= offset) return offset;
+    const fd = fs.openSync(LOG_FILE, 'r');
+    const buf = Buffer.alloc(stat.size - offset);
+    fs.readSync(fd, buf, 0, buf.length, offset);
+    fs.closeSync(fd);
+    for (const line of buf.toString('utf-8').split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const event = JSON.parse(trimmed);
+        out(`[${event.timestamp ?? ''}] ${event.event ?? ''}: ${JSON.stringify(event.details ?? {})}`);
+      } catch {
+        out(trimmed);
+      }
+    }
+    return stat.size;
+  };
+  let offset = tailFile(0);
+  if (!args.follow) return 0;
+  // Simple poll loop for --follow; ctrl-C exits.
+  const interval = setInterval(() => {
+    offset = tailFile(offset);
+  }, 1000);
+  // Return a never-resolving promise via process exit hook isn't useful here;
+  // the user expects --follow to block. Keep the process alive until SIGINT.
+  process.on('SIGINT', () => {
+    clearInterval(interval);
+    process.exit(0);
+  });
+  // Block forever — this function is the entrypoint of the command.
+  return 0;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * armoriq — TypeScript CLI for the ArmorIQ SDK.
+ *
+ * Mirrors the PY CLI command surface from armoriq_sdk/cli.py and cli_auth.py.
+ * Supports: login, logout, whoami, orgs, switch-org, status, logs, keys.
+ *
+ * Note: `init`, `validate`, and `register` (which need MCP JSON-RPC discovery)
+ * are not yet implemented in TS — direct users to the PY CLI for those flows
+ * (or stay tuned for follow-up parity work).
+ */
+
+import { CLIError, CROSS, out } from './util';
+
+const HELP = `
+armoriq — ArmorIQ SDK CLI
+
+Usage: armoriq <command> [options]
+
+Commands:
+  login [--org <name>]       OAuth device-code login flow
+  logout                     Remove cached credentials
+  whoami                     Show the currently logged-in account
+
+  orgs                       List organizations you belong to
+  switch-org <name-or-id>    Switch the active org and rotate API key
+                             [--key-name <name>]
+
+  keys list                  List API keys for this account
+  keys revoke <id>           Revoke a single API key
+  keys prune [--yes]         Revoke expired / unused (>90d) keys
+
+  status                     Show local CLI state (agent, env, MCPs)
+  logs [--follow]            Tail the CLI log file
+
+  help                       Show this help
+
+Use \`armoriq help <command>\` for command-specific options.
+`;
+
+type Argv = string[];
+
+function parseFlag(args: Argv, name: string, hasValue: boolean = true): string | boolean | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === `--${name}`) {
+      if (!hasValue) return true;
+      const v = args[i + 1];
+      args.splice(i, 2);
+      return v;
+    }
+  }
+  return undefined;
+}
+
+async function run(argv: Argv): Promise<number> {
+  const [command, ...rest] = argv;
+
+  if (!command || command === 'help' || command === '--help' || command === '-h') {
+    out(HELP);
+    return 0;
+  }
+
+  switch (command) {
+    case 'login': {
+      const { cmdLogin } = await import('./commands/auth.js');
+      const org = parseFlag(rest, 'org') as string | undefined;
+      const backend = parseFlag(rest, 'backend') as string | undefined;
+      return cmdLogin({ org, backend });
+    }
+    case 'logout': {
+      const { cmdLogout } = await import('./commands/auth.js');
+      return cmdLogout();
+    }
+    case 'whoami': {
+      const { cmdWhoami } = await import('./commands/auth.js');
+      return cmdWhoami();
+    }
+    case 'orgs': {
+      const { cmdOrgs } = await import('./commands/orgs.js');
+      return cmdOrgs();
+    }
+    case 'switch-org': {
+      const { cmdSwitchOrg } = await import('./commands/orgs.js');
+      const keyName = parseFlag(rest, 'key-name') as string | undefined;
+      const target = rest.find((a) => !a.startsWith('--'));
+      if (!target) throw new CLIError('Usage: armoriq switch-org <name-or-id>');
+      return cmdSwitchOrg({ org: target, keyName });
+    }
+    case 'keys': {
+      const sub = rest[0];
+      const { cmdKeysList, cmdKeysRevoke, cmdKeysPrune } = await import('./commands/keys.js');
+      if (sub === 'list') return cmdKeysList();
+      if (sub === 'revoke') {
+        const id = rest[1];
+        if (!id) throw new CLIError('Usage: armoriq keys revoke <id>');
+        return cmdKeysRevoke({ id });
+      }
+      if (sub === 'prune') {
+        const yes = Boolean(parseFlag(rest, 'yes', false));
+        return cmdKeysPrune({ yes });
+      }
+      out('Usage: armoriq keys list | revoke <id> | prune [--yes]');
+      return 1;
+    }
+    case 'status': {
+      const { cmdStatus } = await import('./commands/status.js');
+      return cmdStatus();
+    }
+    case 'logs': {
+      const { cmdLogs } = await import('./commands/status.js');
+      const follow = Boolean(parseFlag(rest, 'follow', false));
+      return cmdLogs({ follow });
+    }
+    case 'init':
+    case 'validate':
+    case 'register': {
+      out(
+        `'armoriq ${command}' is not yet implemented in the TypeScript CLI.\n` +
+          'Use the Python CLI for now (`pip install armoriq-sdk` then `armoriq ' +
+          command +
+          '`), or follow this issue: https://github.com/armoriq/armoriq-sdk-customer-ts/issues/40',
+      );
+      return 1;
+    }
+    default:
+      out(`Unknown command: ${command}`);
+      out(HELP);
+      return 1;
+  }
+}
+
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  run(argv)
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      if (err instanceof CLIError) {
+        out(`  ${CROSS} ${err.message}`);
+        process.exit(1);
+      }
+      out(`  ${CROSS} Unexpected error: ${(err as Error).message}`);
+      process.exit(1);
+    });
+}
+
+export { run as runCli };

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -1,0 +1,63 @@
+/**
+ * Local CLI state ($HOME/.armoriq/{state,cli.log}.{json,jsonl}).
+ * Mirrors the layout used by armoriq_sdk/cli.py so PY and TS CLIs share the same files.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export const ARMORIQ_DIR = path.join(os.homedir(), '.armoriq');
+export const STATE_FILE = path.join(ARMORIQ_DIR, 'state.json');
+export const LOG_FILE = path.join(ARMORIQ_DIR, 'cli.log');
+
+export type CliState = {
+  registered_at?: string;
+  config_path?: string;
+  agent_id?: string;
+  user_id?: string;
+  environment?: string;
+  proxy_endpoint?: string;
+  mcp_servers?: string[];
+  [k: string]: unknown;
+};
+
+export function loadState(): CliState {
+  try {
+    if (!fs.existsSync(STATE_FILE)) return {};
+    return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8')) as CliState;
+  } catch {
+    return {};
+  }
+}
+
+export function saveState(state: CliState): void {
+  fs.mkdirSync(ARMORIQ_DIR, { recursive: true });
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+}
+
+export function clearState(): boolean {
+  try {
+    if (fs.existsSync(STATE_FILE)) {
+      fs.unlinkSync(STATE_FILE);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function appendLog(event: string, details: Record<string, unknown> = {}): void {
+  try {
+    fs.mkdirSync(ARMORIQ_DIR, { recursive: true });
+    const entry = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      event,
+      details,
+    });
+    fs.appendFileSync(LOG_FILE, entry + '\n');
+  } catch {
+    // best-effort; never throw on log write
+  }
+}

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared CLI utilities: console formatting, prompts, env-driven endpoint
+ * resolution, and the "require credentials" guard.
+ */
+
+import * as readline from 'readline';
+import { loadCredentials, getCredentialsPath, Credentials } from '../credentials';
+import { resolveEndpoint } from '../_build_env';
+
+export const CHECK = '\x1b[32m✔\x1b[0m';
+export const CROSS = '\x1b[31m✘\x1b[0m';
+export const WARN = '\x1b[33m!\x1b[0m';
+
+export class CLIError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CLIError';
+  }
+}
+
+export function out(message: string = ''): void {
+  process.stdout.write(message + '\n');
+}
+
+export function maskSecret(secret: string): string {
+  if (!secret) return '';
+  if (secret.length <= 16) return secret;
+  return secret.slice(0, 16) + '...';
+}
+
+export async function prompt(question: string, defaultValue?: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const suffix = defaultValue ? ` [${defaultValue}]` : '';
+  return new Promise((resolve) => {
+    rl.question(`${question}${suffix}: `, (answer) => {
+      rl.close();
+      resolve(answer.trim() || defaultValue || '');
+    });
+  });
+}
+
+export async function promptYesNo(question: string, defaultValue: boolean = false): Promise<boolean> {
+  const hint = defaultValue ? 'Y/n' : 'y/N';
+  const answer = (await prompt(`${question} [${hint}]`)).toLowerCase();
+  if (!answer) return defaultValue;
+  return answer === 'y' || answer === 'yes';
+}
+
+export function backendBase(): string {
+  const explicit = process.env.BACKEND_ENDPOINT || process.env.ARMORIQ_BACKEND_URL;
+  if (explicit) return explicit.replace(/\/+$/, '');
+  return resolveEndpoint('backend').replace(/\/+$/, '');
+}
+
+export function proxyBase(): string {
+  const explicit = process.env.PROXY_ENDPOINT;
+  if (explicit) return explicit.replace(/\/+$/, '');
+  return resolveEndpoint('proxy').replace(/\/+$/, '');
+}
+
+export function requireCredentials(): Credentials {
+  const creds = loadCredentials();
+  if (!creds) {
+    throw new CLIError(
+      `Not logged in (${getCredentialsPath()} missing). Run \`armoriq login\` first.`,
+    );
+  }
+  return creds;
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,6 +17,8 @@ import {
   DelegationRequestResult,
   ApprovedDelegation,
   HoldInfo,
+  McpCredential,
+  McpCredentialMap,
 } from './models';
 import {
   InvalidTokenException,
@@ -82,6 +84,15 @@ export class ArmorIQClient {
   private httpClient: AxiosInstance;
   private tokenCache: Map<string, IntentToken>;
   private metadataCache: Map<string, MCPSemanticMetadata>;
+  private mcpCredentials: McpCredentialMap;
+  private bootstrapCache: Record<string, any> | null = null;
+  private userCache: Map<string, { data: Record<string, any>; expiresAt: number }> = new Map();
+  private userContextTtlSeconds: number = 300;
+  /**
+   * When set by ArmorIQUserScope, all enforcement / token minting calls
+   * are tagged with this email. Read by session and report paths.
+   */
+  public userEmailOverride?: string;
 
   constructor(options: Partial<SDKConfig> & { apiKey?: string; useProduction?: boolean } = {}) {
     // `useProduction: false` is a legacy escape hatch for local dev — treat
@@ -186,6 +197,7 @@ export class ArmorIQClient {
 
     this.tokenCache = new Map();
     this.metadataCache = new Map();
+    this.mcpCredentials = ArmorIQClient.resolveMcpCredentials(options.mcpCredentials);
 
     const mode = (process.env.ARMORIQ_ENV || '').toLowerCase() || ARMORIQ_ENV;
     console.log(
@@ -220,6 +232,198 @@ export class ArmorIQClient {
    */
   get proxyEndpoint(): string {
     return this.defaultProxyEndpoint;
+  }
+
+  /**
+   * Internal accessor for ArmorIQSession and other in-package consumers.
+   * Not part of the public API.
+   * @internal
+   */
+  _sessionInternals() {
+    return {
+      apiKey: this.apiKey,
+      backendEndpoint: this.backendEndpoint,
+      defaultProxyEndpoint: this.defaultProxyEndpoint,
+      httpClient: this.httpClient,
+      userId: this.userId,
+    };
+  }
+
+  /**
+   * Start a session bound to this client. Mirrors PY ArmorIQClient.start_session.
+   */
+  startSession(opts?: import('./session').SessionOptions): import('./session').ArmorIQSession {
+    // Lazy require to keep client.ts free of a hard dependency on session.ts
+    // (and to avoid an import cycle with ArmorIQUserScope).
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { ArmorIQSession } = require('./session') as typeof import('./session');
+    return new ArmorIQSession(this, opts);
+  }
+
+  // ─── Bootstrap ────────────────────────────────────────────────────
+  // Mirrors armoriq_sdk/client.py:bootstrap. Resolves agent identity +
+  // registered MCPs + tool→MCP map from the API key. Cached for the
+  // lifetime of the client; refreshBootstrap() forces a re-fetch.
+
+  async bootstrap(): Promise<Record<string, any>> {
+    if (this.bootstrapCache) return this.bootstrapCache;
+    const resp = await this.httpClient.post(
+      `${this.backendEndpoint}/iap/sdk/bootstrap`,
+      {},
+      { headers: { 'X-API-Key': this.apiKey, 'Content-Type': 'application/json' } },
+    );
+    if (resp.status >= 400) {
+      throw new ConfigurationException(
+        `sdk/bootstrap failed: ${resp.status} ${typeof resp.data === 'string' ? resp.data : JSON.stringify(resp.data)}`,
+      );
+    }
+    this.bootstrapCache = resp.data;
+    return resp.data;
+  }
+
+  async refreshBootstrap(): Promise<Record<string, any>> {
+    this.bootstrapCache = null;
+    return this.bootstrap();
+  }
+
+  // ─── Multi-org / user scope ──────────────────────────────────────
+  // Mirrors armoriq_sdk/client.py:resolve_user / for_user.
+
+  async resolveUser(userEmail: string): Promise<Record<string, any>> {
+    const key = userEmail.trim().toLowerCase();
+    const hit = this.userCache.get(key);
+    if (hit && hit.expiresAt > Date.now() / 1000) {
+      return hit.data;
+    }
+    const resp = await this.httpClient.post(
+      `${this.backendEndpoint}/iap/sdk/resolve-user`,
+      { userEmail: key },
+      { headers: { 'X-API-Key': this.apiKey, 'Content-Type': 'application/json' } },
+    );
+    if (resp.status >= 400) {
+      throw new ConfigurationException(
+        `sdk/resolve-user failed for ${key}: ${resp.status} ${typeof resp.data === 'string' ? resp.data : JSON.stringify(resp.data)}`,
+      );
+    }
+    this.userCache.set(key, {
+      data: resp.data,
+      expiresAt: Date.now() / 1000 + this.userContextTtlSeconds,
+    });
+    return resp.data;
+  }
+
+  invalidateUser(userEmail: string): void {
+    this.userCache.delete(userEmail.trim().toLowerCase());
+  }
+
+  forUser(userEmail: string): ArmorIQUserScope {
+    return new ArmorIQUserScope(this, userEmail);
+  }
+
+  // ─── MCP credential resolution ─────────────────────────────────────
+  // Mirrors armoriq_sdk/client.py:_resolve_mcp_credentials so the same
+  // env JSON / per-MCP env vars work in both SDKs.
+  //   1. ARMORIQ_MCP_CREDENTIALS (JSON object {mcpName: cred})
+  //   2. ARMORIQ_MCP_<SAFE_NAME>_AUTH_TYPE plus matching value vars
+  //   3. constructor option `mcpCredentials` — wins.
+
+  /**
+   * Construct an ArmorIQClient from an armoriq.yaml file. Mirrors PY
+   * ArmorIQClient.from_config — reads YAML, expands $VAR / ${VAR} env refs,
+   * builds the SDKConfig, and returns a ready client.
+   */
+  static fromConfig(filePath: string = 'armoriq.yaml'): ArmorIQClient {
+    // Lazy require to avoid making js-yaml a hard dependency for callers
+    // that never use the YAML loader.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { loadArmorIQConfig, resolveEnvReferences } =
+      require('./config') as typeof import('./config');
+    const cfg = resolveEnvReferences(loadArmorIQConfig(filePath));
+
+    const proxyEndpoints: Record<string, string> = {};
+    const mcpCredentials: Record<string, McpCredential> = {};
+    for (const s of cfg.mcp_servers) {
+      proxyEndpoints[s.id] = s.url;
+      if (s.auth.type === 'bearer' && s.auth.token) {
+        mcpCredentials[s.id] = { authType: 'bearer', token: s.auth.token };
+      } else if (s.auth.type === 'api_key' && s.auth.api_key) {
+        mcpCredentials[s.id] = { authType: 'api_key', apiKey: s.auth.api_key };
+      } else if (s.auth.type === 'none') {
+        mcpCredentials[s.id] = { authType: 'none' };
+      }
+    }
+
+    return new ArmorIQClient({
+      apiKey: cfg.identity.api_key,
+      userId: cfg.identity.user_id,
+      agentId: cfg.identity.agent_id,
+      proxyEndpoint: cfg.proxy.url,
+      timeout: cfg.proxy.timeout * 1000,
+      proxyEndpoints,
+      mcpCredentials,
+    });
+  }
+
+  static resolveMcpCredentials(
+    fromOptions?: McpCredentialMap,
+  ): McpCredentialMap {
+    const merged: McpCredentialMap = {};
+
+    const jsonRaw = process.env.ARMORIQ_MCP_CREDENTIALS;
+    if (jsonRaw) {
+      try {
+        const parsed = JSON.parse(jsonRaw);
+        if (parsed && typeof parsed === 'object') {
+          for (const [k, v] of Object.entries(parsed)) {
+            merged[k] = v as McpCredential;
+          }
+        }
+      } catch (e) {
+        console.warn(`Failed to parse ARMORIQ_MCP_CREDENTIALS as JSON: ${(e as Error).message}`);
+      }
+    }
+
+    const safeNames = new Set<string>();
+    for (const key of Object.keys(process.env)) {
+      const m = /^ARMORIQ_MCP_(.+)_AUTH_TYPE$/.exec(key);
+      if (m) safeNames.add(m[1]);
+    }
+    for (const safe of safeNames) {
+      const authType = (process.env[`ARMORIQ_MCP_${safe}_AUTH_TYPE`] || '').toLowerCase();
+      let cred: McpCredential | undefined;
+      if (authType === 'bearer') {
+        const token = process.env[`ARMORIQ_MCP_${safe}_TOKEN`];
+        if (token) cred = { authType: 'bearer', token };
+      } else if (authType === 'api_key') {
+        const apiKey = process.env[`ARMORIQ_MCP_${safe}_API_KEY`];
+        const headerName = process.env[`ARMORIQ_MCP_${safe}_HEADER_NAME`];
+        if (apiKey) cred = headerName ? { authType: 'api_key', apiKey, headerName } : { authType: 'api_key', apiKey };
+      } else if (authType === 'basic') {
+        const username = process.env[`ARMORIQ_MCP_${safe}_USERNAME`];
+        const password = process.env[`ARMORIQ_MCP_${safe}_PASSWORD`];
+        if (username && password) cred = { authType: 'basic', username, password };
+      } else if (authType === 'none') {
+        cred = { authType: 'none' };
+      }
+      if (cred) merged[safe] = cred;
+    }
+
+    if (fromOptions) {
+      for (const [k, v] of Object.entries(fromOptions)) {
+        merged[k] = v;
+      }
+    }
+    return merged;
+  }
+
+  private getMcpCredential(mcpName: string): McpCredential | undefined {
+    if (this.mcpCredentials[mcpName]) return this.mcpCredentials[mcpName];
+    const safe = mcpName.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+    return this.mcpCredentials[safe];
+  }
+
+  static encodeMcpAuthHeader(cred: McpCredential): string {
+    return Buffer.from(JSON.stringify(cred), 'utf-8').toString('base64');
   }
 
   /**
@@ -474,6 +678,11 @@ export class ArmorIQClient {
 
     if (this.apiKey) {
       headers['X-API-Key'] = this.apiKey;
+    }
+
+    const mcpCred = this.getMcpCredential(mcp);
+    if (mcpCred) {
+      headers['X-Armoriq-MCP-Auth'] = ArmorIQClient.encodeMcpAuthHeader(mcpCred);
     }
 
     // Send CSRG token structure
@@ -1155,5 +1364,33 @@ export class ArmorIQClient {
   close(): void {
     // Axios doesn't require explicit cleanup
     console.log('ArmorIQ SDK client closed');
+  }
+}
+
+/**
+ * User-scoped helper returned by ArmorIQClient.forUser(email).
+ *
+ * Mirrors armoriq_sdk/client.py:ArmorIQUserScope. Tags all token-minting
+ * and enforcement calls with the bound email so multi-user agents route
+ * per-request policies correctly.
+ */
+export class ArmorIQUserScope {
+  public readonly userEmail: string;
+  constructor(private client: ArmorIQClient, userEmail: string) {
+    this.userEmail = userEmail.trim().toLowerCase();
+  }
+
+  startSession(opts?: import('./session').SessionOptions): import('./session').ArmorIQSession {
+    // Lazy import to avoid a cycle between client.ts and session.ts.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { ArmorIQSession } = require('./session') as typeof import('./session');
+    this.client.userEmailOverride = this.userEmail;
+    const session = new ArmorIQSession(this.client, opts);
+    session.userEmail = this.userEmail;
+    return session;
+  }
+
+  async resolve(): Promise<Record<string, any>> {
+    return this.client.resolveUser(this.userEmail);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,235 @@
+/**
+ * armoriq.yaml configuration models and loader.
+ *
+ * Mirrors armoriq_sdk/config.py shape so the same file is portable
+ * between the two SDKs.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+export const DEFAULT_PROXY_URL = 'https://customer-proxy.armoriq.ai';
+
+export class ArmorIQConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArmorIQConfigError';
+  }
+}
+
+/**
+ * Resolve `$ENV_VAR` or `${ENV_VAR}` references against process.env.
+ * Returns the original string when it is not an env reference.
+ */
+export function resolveEnvReference(value: string): string {
+  if (typeof value !== 'string') return value;
+  if (value.startsWith('${') && value.endsWith('}')) {
+    return process.env[value.slice(2, -1)] ?? '';
+  }
+  if (value.startsWith('$') && value.length > 1 && !value.includes(' ')) {
+    return process.env[value.slice(1)] ?? '';
+  }
+  return value;
+}
+
+export interface IdentityConfig {
+  api_key: string;
+  user_id: string;
+  agent_id: string;
+}
+
+export interface ProxyConfig {
+  url: string;
+  timeout: number;
+  max_retries: number;
+}
+
+export type MCPAuthType = 'none' | 'bearer' | 'api_key';
+
+export interface MCPAuthConfig {
+  type: MCPAuthType;
+  token?: string;
+  api_key?: string;
+}
+
+export interface MCPServerConfig {
+  id: string;
+  url: string;
+  description?: string;
+  auth: MCPAuthConfig;
+}
+
+export interface PolicyConfig {
+  allow: string[];
+  deny: string[];
+}
+
+export interface IntentConfig {
+  ttl_seconds: number;
+  require_csrg: boolean;
+}
+
+export type Environment = 'sandbox' | 'production';
+
+export interface ArmorIQConfig {
+  version: 'v1';
+  identity: IdentityConfig;
+  environment: Environment;
+  proxy: ProxyConfig;
+  mcp_servers: MCPServerConfig[];
+  policy: PolicyConfig;
+  intent: IntentConfig;
+}
+
+function normalizeAuth(value: unknown): MCPAuthConfig {
+  if (value === null || value === undefined) return { type: 'none' };
+  if (typeof value === 'string') return { type: value as MCPAuthType };
+  return value as MCPAuthConfig;
+}
+
+function validateIdentity(raw: any): IdentityConfig {
+  if (!raw || typeof raw !== 'object') {
+    throw new ArmorIQConfigError('identity is required');
+  }
+  for (const k of ['api_key', 'user_id', 'agent_id']) {
+    if (typeof raw[k] !== 'string' || !raw[k]) {
+      throw new ArmorIQConfigError(`identity.${k} is required`);
+    }
+  }
+  return { api_key: raw.api_key, user_id: raw.user_id, agent_id: raw.agent_id };
+}
+
+function validateAuth(raw: any): MCPAuthConfig {
+  const a = normalizeAuth(raw);
+  if (a.type === 'bearer' && !a.token) {
+    throw new ArmorIQConfigError("bearer auth requires 'token'");
+  }
+  if (a.type === 'api_key' && !a.api_key) {
+    throw new ArmorIQConfigError("api_key auth requires 'api_key'");
+  }
+  if (a.type !== 'bearer' && a.type !== 'api_key' && a.type !== 'none') {
+    throw new ArmorIQConfigError(`unknown auth type: ${a.type}`);
+  }
+  return a;
+}
+
+export function parseArmorIQConfig(raw: any): ArmorIQConfig {
+  if (!raw || typeof raw !== 'object') {
+    throw new ArmorIQConfigError('config root must be an object');
+  }
+  const version = raw.version ?? 'v1';
+  if (version !== 'v1') {
+    throw new ArmorIQConfigError(`unsupported config version: ${version}`);
+  }
+  const environment = raw.environment ?? 'sandbox';
+  if (environment !== 'sandbox' && environment !== 'production') {
+    throw new ArmorIQConfigError(`environment must be sandbox or production, got: ${environment}`);
+  }
+
+  const proxy: ProxyConfig = {
+    url: raw.proxy?.url ?? DEFAULT_PROXY_URL,
+    timeout: raw.proxy?.timeout ?? 30,
+    max_retries: raw.proxy?.max_retries ?? 3,
+  };
+
+  const policy: PolicyConfig = {
+    allow: Array.isArray(raw.policy?.allow) ? raw.policy.allow : [],
+    deny: Array.isArray(raw.policy?.deny) ? raw.policy.deny : [],
+  };
+
+  const intent: IntentConfig = {
+    ttl_seconds: raw.intent?.ttl_seconds ?? 300,
+    require_csrg: raw.intent?.require_csrg ?? true,
+  };
+
+  const mcpServersRaw: any[] = Array.isArray(raw.mcp_servers) ? raw.mcp_servers : [];
+  const mcpServers: MCPServerConfig[] = mcpServersRaw.map((s, i) => {
+    if (!s.id || typeof s.id !== 'string') {
+      throw new ArmorIQConfigError(`mcp_servers[${i}].id is required`);
+    }
+    if (!s.url || typeof s.url !== 'string') {
+      throw new ArmorIQConfigError(`mcp_servers[${i}].url is required`);
+    }
+    return {
+      id: s.id,
+      url: s.url,
+      description: s.description,
+      auth: validateAuth(s.auth),
+    };
+  });
+  const ids = mcpServers.map((s) => s.id);
+  if (new Set(ids).size !== ids.length) {
+    throw new ArmorIQConfigError("mcp_servers contain duplicate 'id' values");
+  }
+
+  return {
+    version: 'v1',
+    identity: validateIdentity(raw.identity),
+    environment,
+    proxy,
+    mcp_servers: mcpServers,
+    policy,
+    intent,
+  };
+}
+
+export function loadArmorIQConfig(filePath: string = 'armoriq.yaml'): ArmorIQConfig {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new ArmorIQConfigError(`Config file not found: ${resolved}`);
+  }
+  const raw = yaml.load(fs.readFileSync(resolved, 'utf-8')) ?? {};
+  return parseArmorIQConfig(raw);
+}
+
+/**
+ * Resolve every `$VAR` reference in the config against process.env.
+ * Returns a new config with the references replaced by their values.
+ */
+export function resolveEnvReferences(config: ArmorIQConfig): ArmorIQConfig {
+  return {
+    ...config,
+    identity: {
+      api_key: resolveEnvReference(config.identity.api_key),
+      user_id: resolveEnvReference(config.identity.user_id),
+      agent_id: resolveEnvReference(config.identity.agent_id),
+    },
+    mcp_servers: config.mcp_servers.map((s) => ({
+      ...s,
+      url: resolveEnvReference(s.url),
+      auth:
+        s.auth.type === 'bearer'
+          ? { type: 'bearer', token: resolveEnvReference(s.auth.token ?? '') }
+          : s.auth.type === 'api_key'
+            ? { type: 'api_key', api_key: resolveEnvReference(s.auth.api_key ?? '') }
+            : s.auth,
+    })),
+  };
+}
+
+export function saveArmorIQConfig(config: ArmorIQConfig, filePath: string = 'armoriq.yaml'): void {
+  const data: Record<string, any> = {
+    version: config.version,
+    identity: { ...config.identity },
+    environment: config.environment,
+    proxy: { ...config.proxy },
+    mcp_servers: config.mcp_servers.map((s) => {
+      const out: Record<string, any> = {
+        id: s.id,
+        url: s.url,
+        auth:
+          s.auth.type === 'none'
+            ? 'none'
+            : s.auth.type === 'bearer'
+              ? { type: 'bearer', token: s.auth.token }
+              : { type: 'api_key', api_key: s.auth.api_key },
+      };
+      if (s.description) out.description = s.description;
+      return out;
+    }),
+    policy: { allow: config.policy.allow, deny: config.policy.deny },
+    intent: { ttl_seconds: config.intent.ttl_seconds, require_csrg: config.intent.require_csrg },
+  };
+  fs.writeFileSync(filePath, yaml.dump(data, { sortKeys: false }), 'utf-8');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,14 @@
  * @version 0.2.6
  */
 
-export { ArmorIQClient } from './client';
+export { ArmorIQClient, ArmorIQUserScope } from './client';
+export {
+  ArmorIQSession,
+  SessionOptions,
+  SessionMode,
+  EnforceResult,
+  ReportOptions,
+} from './session';
 export {
   ArmorIQException,
   InvalidTokenException,
@@ -37,7 +44,38 @@ export {
   DelegationRequestParams,
   DelegationRequestResult,
   ApprovedDelegation,
+  ToolCall,
+  McpCredential,
+  McpCredentialMap,
 } from './models';
+
+export {
+  defaultToolNameParser,
+  buildPlanFromToolCalls,
+  hashToolCalls,
+  ToolNameParser,
+  PlanStep,
+  BuiltPlan,
+} from './plan_builder';
+
+export {
+  ArmorIQConfig,
+  ArmorIQConfigError,
+  IdentityConfig,
+  ProxyConfig,
+  MCPAuthConfig,
+  MCPAuthType,
+  MCPServerConfig,
+  PolicyConfig,
+  IntentConfig,
+  Environment,
+  loadArmorIQConfig,
+  parseArmorIQConfig,
+  resolveEnvReference,
+  resolveEnvReferences,
+  saveArmorIQConfig,
+  DEFAULT_PROXY_URL,
+} from './config';
 
 export const VERSION = '0.2.6';
 export const AUTHOR = 'ArmorIQ Team';

--- a/src/integrations/google_adk.ts
+++ b/src/integrations/google_adk.ts
@@ -1,0 +1,356 @@
+/**
+ * ArmorIQ — Google ADK integration (TypeScript).
+ *
+ * Mirrors armoriq_sdk/integrations/google_adk.py.
+ *
+ * Multi-user pattern:
+ *
+ *     import { ArmorIQADK } from '@armoriq/sdk/integrations/google_adk';
+ *     const armoriq = new ArmorIQADK({ apiKey: process.env.ARMORIQ_API_KEY! });
+ *
+ *     // per-request, inside your chat handler:
+ *     const scope = await armoriq.forUser(userEmail, { goal: message });
+ *     scope.install(rootAgent);
+ *     try {
+ *       for await (const event of runner.runAsync(...)) { ... }
+ *     } finally {
+ *       scope.uninstall(rootAgent);
+ *     }
+ *
+ * The bundle installs three ADK lifecycle callbacks on the agent:
+ *   afterModelCallback  → mint intent token from LLM tool calls
+ *   beforeToolCallback  → enforce per-user policy, block/hold if needed
+ *   afterToolCallback   → audit report
+ *
+ * "Agent" here is duck-typed — anything with three settable callback
+ * properties works. We don't take a hard dep on a specific TS ADK
+ * package because there isn't a single dominant one yet; the contract
+ * is a bag of three async functions.
+ */
+
+import { ArmorIQClient, ArmorIQUserScope } from '../client';
+import { ToolCall } from '../models';
+import {
+  ArmorIQSession,
+  ReportOptions,
+  SessionMode,
+  SessionOptions,
+} from '../session';
+import { ToolNameParser } from '../plan_builder';
+
+export interface ArmorIQADKOptions {
+  apiKey: string;
+  backendEndpoint?: string;
+  iapEndpoint?: string;
+  proxyEndpoint?: string;
+  useProduction?: boolean;
+  defaultMcpName?: string;
+  toolNameParser?: ToolNameParser;
+  validitySeconds?: number;
+  mode?: SessionMode;
+  llm?: string;
+}
+
+/**
+ * The minimal agent shape we need: three settable callback slots.
+ * Mirrors what google-adk-python expects on its Agent class.
+ */
+export interface AdkLikeAgent {
+  afterModelCallback?: (...args: any[]) => Promise<unknown> | unknown;
+  beforeToolCallback?: (tool: any, args: any, ctx?: any) => Promise<unknown> | unknown;
+  afterToolCallback?: (tool: any, args: any, ctx?: any, response?: any) => Promise<unknown> | unknown;
+}
+
+/**
+ * Process-wide ArmorIQ factory for ADK-style agents.
+ */
+export class ArmorIQADK {
+  public readonly client: ArmorIQClient;
+  public readonly mode: SessionMode;
+  public readonly llm: string;
+  public readonly validitySeconds: number;
+  public readonly defaultMcpName?: string;
+  private customParser?: ToolNameParser;
+  private bootstrapData?: Record<string, any>;
+
+  constructor(opts: ArmorIQADKOptions) {
+    this.client = new ArmorIQClient({
+      apiKey: opts.apiKey,
+      backendEndpoint: opts.backendEndpoint,
+      iapEndpoint: opts.iapEndpoint ?? opts.backendEndpoint,
+      proxyEndpoint: opts.proxyEndpoint ?? opts.backendEndpoint,
+      useProduction: opts.useProduction ?? true,
+      userId: 'agent',
+      agentId: 'agent',
+    });
+    this.defaultMcpName = opts.defaultMcpName;
+    this.customParser = opts.toolNameParser;
+    this.validitySeconds = opts.validitySeconds ?? 300;
+    this.mode = opts.mode ?? 'sdk';
+    this.llm = opts.llm ?? 'agent';
+  }
+
+  async bootstrap(): Promise<Record<string, any>> {
+    if (!this.bootstrapData) {
+      this.bootstrapData = await this.client.bootstrap();
+      const orgName = this.bootstrapData.org?.name ?? 'unknown';
+      const mcps = Array.isArray(this.bootstrapData.mcps)
+        ? this.bootstrapData.mcps.map((m: any) => m.name)
+        : [];
+      const toolMapSize = Object.keys(this.bootstrapData.toolMap ?? {}).length;
+      console.info(
+        `[armoriq] bootstrap: org=${orgName} mcps=${JSON.stringify(mcps)} toolMap=${toolMapSize}`,
+      );
+    }
+    return this.bootstrapData!;
+  }
+
+  private async toolNameParser(): Promise<ToolNameParser> {
+    if (this.customParser) return this.customParser;
+    const bootstrap = await this.bootstrap();
+    const toolMap: Record<string, string> = bootstrap.toolMap ?? {};
+    const defaultMcp = this.defaultMcpName;
+    return (toolName: string) => {
+      const mcp = toolMap[toolName];
+      if (mcp) return { mcp, action: toolName };
+      if (toolName.includes('__')) {
+        const idx = toolName.indexOf('__');
+        return { mcp: toolName.slice(0, idx), action: toolName.slice(idx + 2) };
+      }
+      if (defaultMcp) return { mcp: defaultMcp, action: toolName };
+      return { mcp: 'unknown', action: toolName };
+    };
+  }
+
+  invalidateUser(userEmail: string): void {
+    this.client.invalidateUser(userEmail);
+  }
+
+  async forUser(userEmail: string, opts?: { goal?: string }): Promise<ArmorIQADKBundle> {
+    await this.bootstrap();
+    const scope: ArmorIQUserScope = this.client.forUser(userEmail);
+    const parser = await this.toolNameParser();
+    return new ArmorIQADKBundle({
+      factory: this,
+      scope,
+      parser,
+      userEmail: userEmail.trim().toLowerCase(),
+      goal: opts?.goal ?? 'agent task',
+    });
+  }
+}
+
+/**
+ * Per-request ADK bundle — installs/uninstalls lifecycle callbacks on
+ * one agent and binds them to one user's session.
+ */
+export class ArmorIQADKBundle {
+  public readonly userEmail: string;
+  public readonly goal: string;
+  public session?: ArmorIQSession;
+  private factory: ArmorIQADK;
+  private scope: ArmorIQUserScope;
+  private parser: ToolNameParser;
+  private planMinted = false;
+  private blockedTools = new Set<string>();
+  private blockedActions = new Map<string, string>();
+  private agent?: AdkLikeAgent;
+  private saved: {
+    afterModelCallback?: AdkLikeAgent['afterModelCallback'];
+    beforeToolCallback?: AdkLikeAgent['beforeToolCallback'];
+    afterToolCallback?: AdkLikeAgent['afterToolCallback'];
+  } = {};
+
+  constructor(args: {
+    factory: ArmorIQADK;
+    scope: ArmorIQUserScope;
+    parser: ToolNameParser;
+    userEmail: string;
+    goal: string;
+  }) {
+    this.factory = args.factory;
+    this.scope = args.scope;
+    this.parser = args.parser;
+    this.userEmail = args.userEmail;
+    this.goal = args.goal;
+  }
+
+  private ensureSession(): ArmorIQSession {
+    if (!this.session) {
+      const opts: SessionOptions = {
+        mode: this.factory.mode,
+        validitySeconds: this.factory.validitySeconds,
+        llm: this.factory.llm,
+        toolNameParser: this.parser,
+        defaultMcpName: this.factory.defaultMcpName,
+      };
+      this.session = this.scope.startSession(opts);
+    }
+    return this.session;
+  }
+
+  private async afterModel(_callbackContext: any, llmResponse: any): Promise<unknown> {
+    try {
+      if (this.planMinted) return null;
+      const parts = llmResponse?.content?.parts ?? [];
+      const toolCalls: ToolCall[] = [];
+      for (const p of parts) {
+        const fc = p?.functionCall ?? p?.function_call;
+        if (fc?.name) {
+          toolCalls.push({ name: fc.name, args: fc.args ? { ...fc.args } : {} });
+        }
+      }
+      if (toolCalls.length === 0) return null;
+      await this.ensureSession().startPlan(toolCalls, this.goal);
+      this.planMinted = true;
+      console.info(`[armoriq] plan minted user=${this.userEmail} tools=${toolCalls.length}`);
+    } catch (exc) {
+      console.warn(`[armoriq] afterModelCallback failed: ${(exc as Error).message}`);
+    }
+    return null;
+  }
+
+  private async beforeTool(tool: any, args: any, _toolContext?: any): Promise<unknown> {
+    const toolName: string = tool?.name ?? String(tool);
+    try {
+      const decision = await this.ensureSession().check(toolName, args ?? {}, this.userEmail);
+      if (!decision.allowed) {
+        const policy = decision.matchedPolicy ? ` (policy: ${decision.matchedPolicy})` : '';
+
+        if (decision.action === 'hold') {
+          console.info(
+            `[armoriq] HELD ${toolName} user=${this.userEmail} reason=${decision.reason} — waiting for approval...`,
+          );
+          // 30-min default, 3s → 15s exponential, matches PY hold-retry.
+          const timeoutMs = 30 * 60 * 1000;
+          const deadline = Date.now() + timeoutMs;
+          let pollIntervalMs = 3000;
+          let attempt = 0;
+          let approved = false;
+          let finalDecision = decision;
+          while (Date.now() < deadline) {
+            await new Promise((r) => setTimeout(r, pollIntervalMs));
+            pollIntervalMs = Math.min(pollIntervalMs * 1.5, 15000);
+            attempt += 1;
+            const retry = await this.ensureSession().check(
+              toolName,
+              args ?? {},
+              this.userEmail,
+            );
+            finalDecision = retry;
+            if (retry.allowed) {
+              console.info(`[armoriq] APPROVED ${toolName} attempt ${attempt}`);
+              approved = true;
+              break;
+            }
+            if (retry.action !== 'hold') {
+              console.info(`[armoriq] REJECTED ${toolName} action=${retry.action}`);
+              break;
+            }
+          }
+
+          if (approved) return null;
+
+          const finalPolicy = finalDecision.matchedPolicy
+            ? ` (policy: ${finalDecision.matchedPolicy})`
+            : '';
+          this.blockedTools.add(toolName);
+          this.blockedActions.set(toolName, finalDecision.action);
+          if (finalDecision.action === 'hold') {
+            return {
+              error: `Approval timed out${finalPolicy}. Reason: ${finalDecision.reason ?? 'policy-hold'}.`,
+              armoriq_enforcement: {
+                blocked: true,
+                action: 'hold',
+                reason: finalDecision.reason,
+                matched_policy: finalDecision.matchedPolicy,
+                tool: toolName,
+                delegation_id: finalDecision.delegationId,
+              },
+            };
+          }
+          return {
+            error: `This action is not permitted${finalPolicy}. Reason: ${finalDecision.reason ?? 'policy-blocked'}.`,
+            armoriq_enforcement: {
+              blocked: true,
+              action: finalDecision.action,
+              reason: finalDecision.reason,
+              matched_policy: finalDecision.matchedPolicy,
+              tool: toolName,
+              delegation_id: finalDecision.delegationId,
+            },
+          };
+        }
+
+        // Hard block
+        this.blockedTools.add(toolName);
+        this.blockedActions.set(toolName, decision.action);
+        console.info(
+          `[armoriq] BLOCKED ${toolName} user=${this.userEmail} action=${decision.action} reason=${decision.reason}`,
+        );
+        return {
+          error: `This action is not permitted by your organization's policy${policy}. Reason: ${decision.reason ?? 'policy-blocked'}.`,
+          armoriq_enforcement: {
+            blocked: true,
+            action: decision.action,
+            reason: decision.reason,
+            matched_policy: decision.matchedPolicy,
+            tool: toolName,
+            delegation_id: decision.delegationId,
+          },
+        };
+      }
+    } catch (exc) {
+      console.warn(`[armoriq] beforeToolCallback failed: ${(exc as Error).message}`);
+    }
+    return null;
+  }
+
+  private async afterTool(tool: any, args: any, _toolContext: any, toolResponse: any): Promise<unknown> {
+    const toolName: string = tool?.name ?? String(tool);
+    try {
+      if (this.blockedTools.has(toolName)) {
+        const action = this.blockedActions.get(toolName) ?? 'block';
+        this.blockedActions.delete(toolName);
+        this.blockedTools.delete(toolName);
+        if (action !== 'hold') {
+          await this.ensureSession().report(toolName, args ?? {}, toolResponse, {
+            status: 'failed',
+            errorMessage: 'Blocked by policy',
+          } as ReportOptions);
+        }
+        return null;
+      }
+      await this.ensureSession().report(toolName, args ?? {}, toolResponse);
+    } catch (exc) {
+      console.warn(`[armoriq] afterToolCallback failed: ${(exc as Error).message}`);
+    }
+    return null;
+  }
+
+  /**
+   * Attach the three callbacks to the ADK-style agent. Save originals
+   * for uninstall().
+   */
+  install(agent: AdkLikeAgent): this {
+    this.agent = agent;
+    this.saved = {
+      afterModelCallback: agent.afterModelCallback,
+      beforeToolCallback: agent.beforeToolCallback,
+      afterToolCallback: agent.afterToolCallback,
+    };
+    agent.afterModelCallback = (...args: any[]) => this.afterModel(args[0], args[1]);
+    agent.beforeToolCallback = (tool: any, args: any, ctx?: any) => this.beforeTool(tool, args, ctx);
+    agent.afterToolCallback = (tool: any, args: any, ctx?: any, response?: any) =>
+      this.afterTool(tool, args, ctx, response);
+    return this;
+  }
+
+  uninstall(agent?: AdkLikeAgent): void {
+    const a = agent ?? this.agent;
+    if (!a) return;
+    a.afterModelCallback = this.saved.afterModelCallback;
+    a.beforeToolCallback = this.saved.beforeToolCallback;
+    a.afterToolCallback = this.saved.afterToolCallback;
+  }
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -255,6 +255,31 @@ export interface ApprovedDelegation {
 }
 
 /**
+ * A flat tool-call as surfaced by most LLM frameworks.
+ * Used by plan_builder helpers and ArmorIQSession.startPlan.
+ */
+export interface ToolCall {
+  name: string;
+  args?: Record<string, unknown>;
+}
+
+/**
+ * Per-MCP credentials forwarded to the proxy via the X-Armoriq-MCP-Auth header.
+ * The discriminated union mirrors the Python SDK's McpCredential shape so
+ * the JSON env blob (ARMORIQ_MCP_CREDENTIALS) is portable across SDKs.
+ */
+export type McpCredential =
+  | { authType: 'bearer'; token: string }
+  | { authType: 'api_key'; apiKey: string; headerName?: string }
+  | { authType: 'basic'; username: string; password: string }
+  | { authType: 'none' };
+
+/**
+ * Map of MCP identifier (or upper-snake "safe name") to credential.
+ */
+export type McpCredentialMap = Record<string, McpCredential>;
+
+/**
  * SDK configuration.
  */
 export interface SDKConfig {
@@ -280,4 +305,9 @@ export interface SDKConfig {
   apiKey?: string;
   /** Use production endpoints */
   useProduction: boolean;
+  /**
+   * Per-MCP credentials. Merged with ARMORIQ_MCP_CREDENTIALS env JSON and
+   * ARMORIQ_MCP_<SAFE_NAME>_* per-MCP env vars; constructor option wins.
+   */
+  mcpCredentials?: McpCredentialMap;
 }

--- a/src/plan_builder.ts
+++ b/src/plan_builder.ts
@@ -1,0 +1,101 @@
+/**
+ * Plan-shape helpers used by ArmorIQSession and framework integrations.
+ *
+ * Most LLM frameworks surface tool calls as a flat list of {name, args}.
+ * The SDK accepts that shape directly so plugin code doesn't have to
+ * hand-construct {goal, steps: [...]} every time.
+ *
+ * Mirrors armoriq_sdk/plan_builder.py — outputs the same plan shape and
+ * hash digest so PY and TS sides round-trip cleanly.
+ */
+
+import * as crypto from 'crypto';
+import { ToolCall } from './models';
+
+export type ToolNameParser = (toolName: string) => { mcp: string; action: string };
+
+/**
+ * Default tool-name convention: `<MCP>__<action>`. Matches the proxy's
+ * MCP gateway and the convention used by sdk-admin-agent.
+ *
+ *   "Stripe__create_payment" -> { mcp: "Stripe", action: "create_payment" }
+ *   "create_payment"          -> uses defaultMcpName, else throws.
+ */
+export function defaultToolNameParser(defaultMcpName?: string): ToolNameParser {
+  return (toolName: string) => {
+    const idx = toolName.indexOf('__');
+    if (idx === -1) {
+      if (!defaultMcpName) {
+        throw new Error(
+          `Tool "${toolName}" is not namespaced as <MCP>__<action> and no defaultMcpName was set on the session.`,
+        );
+      }
+      return { mcp: defaultMcpName, action: toolName };
+    }
+    const mcp = toolName.slice(0, idx);
+    const action = toolName.slice(idx + 2);
+    if (!mcp || !action) {
+      throw new Error(`Tool "${toolName}" has a malformed MCP prefix.`);
+    }
+    return { mcp, action };
+  };
+}
+
+function asToolCall(tc: ToolCall | { name: string; args?: Record<string, unknown> }): ToolCall {
+  return { name: tc.name, args: tc.args ?? {} };
+}
+
+export interface PlanStep {
+  action: string;
+  tool: string;
+  mcp: string;
+  params: Record<string, unknown>;
+  description: string;
+}
+
+export interface BuiltPlan {
+  goal: string;
+  steps: PlanStep[];
+}
+
+/**
+ * Build an SDK-shaped plan dict from a flat list of tool calls.
+ */
+export function buildPlanFromToolCalls(
+  toolCalls: Array<ToolCall | { name: string; args?: Record<string, unknown> }>,
+  goal?: string,
+  toolNameParser?: ToolNameParser,
+  defaultMcpName?: string,
+): BuiltPlan {
+  const parser = toolNameParser ?? defaultToolNameParser(defaultMcpName);
+  const steps: PlanStep[] = toolCalls.map((tc) => {
+    const call = asToolCall(tc);
+    const { mcp, action } = parser(call.name);
+    return {
+      action,
+      tool: action,
+      mcp,
+      params: (call.args as Record<string, unknown>) ?? {},
+      description: `Call ${action} on ${mcp}`,
+    };
+  });
+  return { goal: goal ?? 'agent task', steps };
+}
+
+/**
+ * Stable hash over a tool-calls list — used by ArmorIQSession to skip
+ * re-minting when the LLM re-emits the same plan in the same turn.
+ *
+ * Uses JSON.stringify with no key sorting, matching the Python side's
+ * json.dumps(separators=(",",":")), so TS and PY produce matching digests.
+ */
+export function hashToolCalls(
+  toolCalls: Array<ToolCall | { name: string; args?: Record<string, unknown> }>,
+): string {
+  const canonicalList = toolCalls.map((tc) => ({
+    name: asToolCall(tc).name,
+    args: asToolCall(tc).args ?? {},
+  }));
+  const canonical = JSON.stringify(canonicalList);
+  return crypto.createHash('sha256').update(canonical, 'utf8').digest('hex');
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,603 @@
+/**
+ * ArmorIQSession — the core primitive for framework integrations.
+ *
+ * Mirrors armoriq_sdk/session.py. Two main usage shapes:
+ *
+ * 1. Observe mode (default, local) — MCP stays on the agent side:
+ *      session.startPlan(toolCalls);
+ *      const decision = session.enforce(toolName, toolArgs);
+ *      // ... framework calls MCP directly ...
+ *      await session.report(toolName, toolArgs, result);
+ *
+ * 2. Proxy mode — routes through the Armoriq proxy:
+ *      session.startPlan(toolCalls);
+ *      return session.dispatch(toolName, toolArgs);
+ */
+
+import { ArmorIQClient } from './client';
+import { IntentToken, ToolCall } from './models';
+import {
+  ToolNameParser,
+  defaultToolNameParser,
+  buildPlanFromToolCalls,
+  hashToolCalls,
+} from './plan_builder';
+
+export type SessionMode = 'local' | 'proxy' | 'sdk';
+
+export interface SessionOptions {
+  toolNameParser?: ToolNameParser;
+  defaultMcpName?: string;
+  validitySeconds?: number;
+  llm?: string;
+  mode?: SessionMode;
+}
+
+export interface EnforceResult {
+  allowed: boolean;
+  action: 'allow' | 'block' | 'hold';
+  reason?: string;
+  delegationId?: string;
+  matchedPolicy?: string;
+}
+
+export interface ReportOptions {
+  status?: 'success' | 'failed' | 'error';
+  errorMessage?: string;
+  durationMs?: number;
+  isDelegated?: boolean;
+  delegatedBy?: string;
+  delegatedTo?: string;
+}
+
+type ToolCallInput = ToolCall | { name: string; args?: Record<string, unknown> };
+
+export class ArmorIQSession {
+  public userEmail?: string;
+  private client: ArmorIQClient;
+  private toolNameParser: ToolNameParser;
+  private defaultMcpName?: string;
+  private validitySeconds: number;
+  private llm: string;
+  private mode: SessionMode;
+  private stepIndex = 0;
+  private currentPlanHash?: string;
+  private currentToken?: IntentToken;
+  private mcpByAction: Map<string, string> = new Map();
+  private declaredTools: Set<string> = new Set();
+
+  constructor(client: ArmorIQClient, opts?: SessionOptions) {
+    this.client = client;
+    const o = opts ?? {};
+    this.defaultMcpName = o.defaultMcpName;
+    this.toolNameParser = o.toolNameParser ?? defaultToolNameParser(this.defaultMcpName);
+    this.validitySeconds = o.validitySeconds ?? 3600;
+    this.llm = o.llm ?? 'agent';
+    this.mode = o.mode ?? 'local';
+  }
+
+  // ─── Plan capture ──────────────────────────────────────────────
+
+  async startPlan(toolCalls: ToolCallInput[], goal?: string): Promise<IntentToken> {
+    if (!toolCalls || toolCalls.length === 0) {
+      throw new Error('startPlan called with no tool calls.');
+    }
+    const h = hashToolCalls(toolCalls);
+    if (this.currentToken && this.currentPlanHash === h) {
+      return this.currentToken;
+    }
+
+    const plan = buildPlanFromToolCalls(
+      toolCalls,
+      goal,
+      this.toolNameParser,
+      this.defaultMcpName,
+    );
+
+    this.mcpByAction.clear();
+    this.declaredTools.clear();
+    for (const step of plan.steps) {
+      this.mcpByAction.set(step.action, step.mcp);
+      this.declaredTools.add(step.action);
+      this.declaredTools.add(`${step.mcp}__${step.action}`);
+    }
+    for (const tc of toolCalls) {
+      this.declaredTools.add(tc.name);
+    }
+
+    const planCapture = this.client.capturePlan(this.llm, goal ?? this.llm, plan);
+    const token = await this.client.getIntentToken(planCapture, undefined, this.validitySeconds);
+    this.currentPlanHash = h;
+    this.currentToken = token;
+    this.stepIndex = 0;
+    return token;
+  }
+
+  // ─── Policy enforcement ────────────────────────────────────────
+
+  enforceLocal(toolName: string, toolArgs: Record<string, unknown>): EnforceResult {
+    if (!this.currentToken) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: 'No intent token — call startPlan() first',
+      };
+    }
+    if (IntentToken.isExpired(this.currentToken)) {
+      return { allowed: false, action: 'block', reason: 'token-expired' };
+    }
+    const { mcp, action } = this.toolNameParser(toolName);
+    const inPlan =
+      this.declaredTools.has(toolName) ||
+      this.declaredTools.has(action) ||
+      this.declaredTools.has(`${mcp}__${action}`);
+    if (!inPlan) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: `tool-not-in-plan: '${toolName}' was not declared in the captured plan`,
+      };
+    }
+
+    const pv = (this.currentToken.policyValidation ?? {}) as Record<string, any>;
+    const snapshot = (this.currentToken.policySnapshot ?? []) as Array<Record<string, any>>;
+
+    const ruleOf = (entry: any): any => {
+      if (!entry || typeof entry !== 'object') return entry;
+      return entry.memberRule ?? entry.clientRule ?? entry.rules ?? entry;
+    };
+
+    let governingEntry: Record<string, any> | undefined;
+    if (Array.isArray(snapshot)) {
+      for (const entry of snapshot) {
+        const r = ruleOf(entry);
+        if (!r) continue;
+        const allowed = r.allowedTools ?? [];
+        if (!Array.isArray(allowed)) continue;
+        if (allowed.includes(action) || allowed.includes(toolName)) {
+          governingEntry = entry;
+          break;
+        }
+        if (allowed.some((t: string) => t === '*' || t.endsWith('/*') || t.endsWith('*'))) {
+          governingEntry = entry;
+          break;
+        }
+        const target = String(entry.targetName ?? entry.policyName ?? '').toLowerCase();
+        if (mcp && target.includes(mcp.toLowerCase())) {
+          governingEntry = entry;
+          break;
+        }
+      }
+    }
+
+    const governingRule = governingEntry ? ruleOf(governingEntry) : undefined;
+    const governingPolicyName: string | undefined = governingEntry?.policyName;
+    const notAllowedAction =
+      governingEntry?.defaultEnforcementAction ?? pv.default_enforcement_action ?? 'block';
+
+    const deniedTools = pv.denied_tools;
+    if (Array.isArray(deniedTools)) {
+      if (deniedTools.includes(toolName) || deniedTools.includes(action)) {
+        const deniedReasons: string[] = pv.denied_reasons ?? [];
+        const reasonFromBackend = deniedReasons.find(
+          (r) => r.startsWith(`${action}:`) || r.startsWith(`${toolName}:`),
+        );
+        const reason =
+          reasonFromBackend ??
+          (governingPolicyName
+            ? `Tool '${action}' is denied by policy '${governingPolicyName}'`
+            : `Tool '${action}' is denied by policy`);
+        return {
+          allowed: false,
+          action: notAllowedAction === 'hold' ? 'hold' : 'block',
+          reason,
+          matchedPolicy: governingPolicyName,
+        };
+      }
+    }
+
+    if (governingRule) {
+      const allowed = governingRule.allowedTools ?? [];
+      if (Array.isArray(allowed) && allowed.length > 0) {
+        const ok =
+          allowed.includes('*') ||
+          allowed.includes(action) ||
+          allowed.includes(toolName);
+        if (!ok) {
+          return {
+            allowed: false,
+            action: notAllowedAction === 'hold' ? 'hold' : 'block',
+            reason: `Tool '${action}' is not in the allowed tools for policy '${governingPolicyName}'`,
+            matchedPolicy: governingPolicyName,
+          };
+        }
+      }
+    } else if (Array.isArray(snapshot) && snapshot.length > 0) {
+      const allowedTools = pv.allowed_tools;
+      if (Array.isArray(allowedTools) && allowedTools.length === 0) {
+        return {
+          allowed: false,
+          action: 'block',
+          reason: `Tool '${action}' is not allowed by any policy in scope`,
+        };
+      }
+    }
+
+    if (governingRule) {
+      const thresholdDecision = this.evaluateAmountThreshold(
+        governingRule,
+        toolArgs,
+        action,
+        mcp,
+      );
+      if (thresholdDecision) {
+        thresholdDecision.matchedPolicy = governingPolicyName;
+        return thresholdDecision;
+      }
+    }
+
+    return {
+      allowed: true,
+      action: 'allow',
+      reason: 'Allowed by local policy evaluation',
+      matchedPolicy: governingPolicyName,
+    };
+  }
+
+  async enforceSdk(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+    userEmail?: string,
+  ): Promise<EnforceResult> {
+    if (!this.currentToken) {
+      throw new Error(`enforceSdk("${toolName}") called before startPlan().`);
+    }
+    const { mcp, action } = this.toolNameParser(toolName);
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+    const inPlan =
+      this.declaredTools.has(toolName) ||
+      this.declaredTools.has(action) ||
+      this.declaredTools.has(`${resolvedMcp}__${action}`);
+    if (!inPlan) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: `tool-not-in-plan: '${toolName}' was not declared in the captured plan`,
+      };
+    }
+
+    const internals = this.client._sessionInternals();
+    try {
+      const response = await internals.httpClient.post(
+        `${internals.backendEndpoint}/iap/sdk/enforce`,
+        {
+          tool: action,
+          arguments: toolArgs,
+          intent_token: this.currentToken.rawToken,
+          policy_snapshot: this.currentToken.policySnapshot,
+          user_email: userEmail,
+        },
+        {
+          headers: { 'X-API-Key': internals.apiKey, 'Content-Type': 'application/json' },
+          timeout: 10000,
+        },
+      );
+      const data = response.data ?? {};
+      const allowed = data.allowed !== false;
+      const actionDecision: 'allow' | 'block' | 'hold' =
+        data.enforcementAction ?? (allowed ? 'allow' : 'block');
+      const matched: string | undefined =
+        typeof data.matchedPolicy === 'object'
+          ? data.matchedPolicy?.name
+          : data.matchedPolicy;
+      if (actionDecision === 'hold') {
+        return this.handleHold(
+          toolName,
+          toolArgs,
+          {
+            allowed: false,
+            action: 'hold',
+            reason: data.reason ?? data.message,
+            matchedPolicy: matched,
+          },
+          userEmail,
+        );
+      }
+      return {
+        allowed,
+        action: actionDecision,
+        reason: data.reason ?? data.message,
+        matchedPolicy: matched,
+      };
+    } catch (e) {
+      console.warn(`enforceSdk() failed: ${(e as Error).message}. Allowing tool call.`);
+      return { allowed: true, action: 'allow', reason: 'enforce-unavailable' };
+    }
+  }
+
+  async enforce(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+  ): Promise<EnforceResult> {
+    if (!this.currentToken) {
+      throw new Error(`enforce("${toolName}") called before startPlan().`);
+    }
+    const { mcp, action } = this.toolNameParser(toolName);
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+    const inPlan =
+      this.declaredTools.has(toolName) ||
+      this.declaredTools.has(action) ||
+      this.declaredTools.has(`${resolvedMcp}__${action}`);
+    if (!inPlan) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: `tool-not-in-plan: '${toolName}' was not declared in the captured plan`,
+      };
+    }
+
+    const internals = this.client._sessionInternals();
+    try {
+      const payload: Record<string, unknown> = {
+        enforce_only: true,
+        mcp: resolvedMcp,
+        tool: action,
+        action,
+        params: toolArgs,
+        arguments: toolArgs,
+        intent_token: this.currentToken.rawToken,
+        plan: (this.currentToken.rawToken ?? {}).plan,
+      };
+      if (this.currentToken.policySnapshot) {
+        payload.policy_snapshot = this.currentToken.policySnapshot;
+      }
+      const response = await internals.httpClient.post(
+        `${internals.defaultProxyEndpoint}/invoke`,
+        payload,
+        {
+          headers: { 'X-API-Key': internals.apiKey, 'Content-Type': 'application/json' },
+          timeout: 10000,
+        },
+      );
+      if (response.status === 403) {
+        const data = response.data ?? {};
+        return {
+          allowed: false,
+          action: data.action ?? 'block',
+          reason: data.reason ?? data.message,
+          matchedPolicy:
+            typeof data.matched_policy === 'object'
+              ? data.matched_policy?.name
+              : data.matched_policy,
+        };
+      }
+      const data = response.data ?? {};
+      const rawPolicy = data.matched_policy ?? data.matchedPolicy;
+      const policyName =
+        rawPolicy && typeof rawPolicy === 'object' ? rawPolicy.name : rawPolicy;
+      const allowedFlag = data.allowed !== false;
+      const actionDecision: 'allow' | 'block' | 'hold' =
+        data.enforcementAction ?? data.action ?? (allowedFlag ? 'allow' : 'block');
+      return {
+        allowed: allowedFlag,
+        action: actionDecision,
+        reason: data.reason,
+        delegationId: data.delegation_id,
+        matchedPolicy: policyName,
+      };
+    } catch (e) {
+      console.warn(`enforce() failed: ${(e as Error).message}. Allowing tool call.`);
+      return { allowed: true, action: 'allow', reason: 'enforce-unavailable' };
+    }
+  }
+
+  async check(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+    userEmail?: string,
+  ): Promise<EnforceResult> {
+    if (this.mode === 'sdk') {
+      return this.enforceSdk(toolName, toolArgs, userEmail);
+    }
+    if (this.mode === 'local') {
+      const decision = this.enforceLocal(toolName, toolArgs);
+      if (decision.action === 'hold') {
+        return {
+          ...decision,
+          action: 'block',
+          reason:
+            (decision.reason ?? 'requires approval') +
+            ' — switch ARMORIQ_MODE=proxy to enable approval workflows for this action.',
+        };
+      }
+      return decision;
+    }
+    const decision = await this.enforce(toolName, toolArgs);
+    if (decision.action !== 'hold') return decision;
+    return this.handleHold(toolName, toolArgs, decision, userEmail);
+  }
+
+  // ─── Report / dispatch ─────────────────────────────────────────
+
+  async report(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+    result: unknown,
+    opts?: ReportOptions,
+  ): Promise<void> {
+    const o = opts ?? {};
+    const { mcp, action } = this.toolNameParser(toolName);
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+    const internals = this.client._sessionInternals();
+    try {
+      const token = this.currentToken;
+      const userEmail = this.userEmail ?? this.client.userEmailOverride;
+      let output: unknown = result;
+      if (typeof result === 'string') output = { text: result };
+      else if (result === null || result === undefined) output = {};
+
+      await internals.httpClient.post(
+        `${internals.backendEndpoint}/iap/audit`,
+        {
+          token: token?.jwtToken ?? token?.tokenId ?? 'unknown',
+          plan_id: token?.planId ?? token?.tokenId ?? 'unknown',
+          step_index: this.stepIndex,
+          action,
+          tool: action,
+          mcp: resolvedMcp,
+          input: toolArgs,
+          output,
+          status: o.status ?? 'success',
+          error_message: o.errorMessage,
+          duration_ms: o.durationMs,
+          is_delegated: o.isDelegated,
+          delegated_by: o.delegatedBy,
+          user_email: userEmail,
+          delegated_to: o.delegatedTo,
+          executed_at: new Date().toISOString(),
+        },
+        {
+          headers: { 'X-API-Key': internals.apiKey, 'Content-Type': 'application/json' },
+          timeout: 5000,
+        },
+      );
+    } catch (e) {
+      console.warn(`report() failed: ${(e as Error).message}`);
+    }
+    this.stepIndex += 1;
+  }
+
+  async dispatch(toolName: string, toolArgs: Record<string, unknown>): Promise<unknown> {
+    if (!this.currentToken) {
+      throw new Error(`dispatch("${toolName}") called before startPlan().`);
+    }
+    const { mcp, action } = this.toolNameParser(toolName);
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+    const result = await this.client.invoke(resolvedMcp, action, this.currentToken, toolArgs);
+    this.stepIndex += 1;
+    return result.result;
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────
+
+  private async handleHold(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+    holdDecision: EnforceResult,
+    userEmail?: string,
+  ): Promise<EnforceResult> {
+    const internals = this.client._sessionInternals();
+    const email = userEmail ?? internals.userId ?? 'unknown@armoriq';
+    const { mcp, action } = this.toolNameParser(toolName);
+    const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
+    const amount = ArmorIQSession.extractAmount(toolArgs) ?? 0;
+
+    try {
+      const approved = await this.client.checkApprovedDelegation(email, action, amount);
+      if (approved) {
+        try {
+          if (approved.delegationId) {
+            await this.client.markDelegationExecuted(email, approved.delegationId);
+          }
+        } catch {
+          // best-effort
+        }
+        return {
+          allowed: true,
+          action: 'allow',
+          reason: `Allowed by approved delegation ${approved.delegationId ?? ''}`.trim(),
+          delegationId: approved.delegationId,
+          matchedPolicy: holdDecision.matchedPolicy,
+        };
+      }
+    } catch {
+      // best-effort
+    }
+
+    let delegationId: string | undefined;
+    try {
+      const result = await this.client.createDelegationRequest({
+        tool: action,
+        action,
+        arguments: toolArgs,
+        amount: amount || undefined,
+        requesterEmail: email,
+        domain: resolvedMcp,
+        planId: this.currentToken?.planId,
+        intentReference: this.currentToken?.tokenId,
+        merkleRoot: (this.currentToken?.rawToken ?? {}).merkle_root,
+        reason: holdDecision.reason,
+      });
+      delegationId = result.delegationId;
+    } catch (e) {
+      console.warn(`createDelegationRequest failed: ${(e as Error).message}`);
+    }
+
+    return {
+      allowed: false,
+      action: 'hold',
+      reason: holdDecision.reason ?? 'Pending approval',
+      delegationId,
+      matchedPolicy: holdDecision.matchedPolicy,
+    };
+  }
+
+  private static extractAmount(args: Record<string, unknown>): number | undefined {
+    if (!args || typeof args !== 'object') return undefined;
+    for (const k of ['amount', 'value', 'total', 'price', 'cost']) {
+      const v = (args as Record<string, unknown>)[k];
+      if (v === undefined || v === null) continue;
+      const n = typeof v === 'number' ? v : Number(v);
+      if (Number.isFinite(n)) return n;
+    }
+    return undefined;
+  }
+
+  private evaluateAmountThreshold(
+    rule: Record<string, any>,
+    toolArgs: Record<string, unknown>,
+    action: string,
+    mcp: string,
+  ): EnforceResult | undefined {
+    const fin = rule.financialRule?.amountThreshold ?? rule.amountThreshold;
+    if (!fin || typeof fin !== 'object') return undefined;
+    const amount = ArmorIQSession.extractAmount(toolArgs);
+    if (amount === undefined) return undefined;
+    const currency = fin.currency ?? '';
+    const maxPer = fin.maxPerTransaction;
+    const reqApproval = fin.requireApprovalAbove;
+    if (typeof maxPer === 'number' && amount > maxPer) {
+      return {
+        allowed: false,
+        action: 'block',
+        reason: `Amount ${amount} ${currency} exceeds maxPerTransaction (${maxPer})`.trim(),
+      };
+    }
+    if (typeof reqApproval === 'number' && amount > reqApproval) {
+      return {
+        allowed: false,
+        action: 'hold',
+        reason: `Amount ${amount} ${currency} requires approval (threshold: ${reqApproval})`.trim(),
+      };
+    }
+    return undefined;
+  }
+
+  // ─── Session state ────────────────────────────────────────────
+
+  reset(): void {
+    this.currentPlanHash = undefined;
+    this.currentToken = undefined;
+    this.mcpByAction.clear();
+    this.declaredTools.clear();
+    this.stepIndex = 0;
+  }
+
+  get currentTokenValue(): IntentToken | undefined {
+    return this.currentToken;
+  }
+
+  get currentMode(): SessionMode {
+    return this.mode;
+  }
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Light smoke tests for the CLI dispatcher and pure helpers.
+ * Network-touching commands (login, orgs, switch-org, keys) are exercised
+ * via the E2E suite — these tests just verify command routing & help.
+ */
+
+import { runCli } from '../src/cli/index';
+import * as state from '../src/cli/state';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+describe('CLI dispatcher', () => {
+  let stdoutSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it('prints help for the help command', async () => {
+    const code = await runCli(['help']);
+    expect(code).toBe(0);
+    const output = stdoutSpy.mock.calls.map((c) => c[0]).join('');
+    expect(output).toMatch(/login/);
+    expect(output).toMatch(/keys list/);
+    expect(output).toMatch(/switch-org/);
+  });
+
+  it('returns 1 and prints help for an unknown command', async () => {
+    const code = await runCli(['totally-not-a-command']);
+    expect(code).toBe(1);
+    const output = stdoutSpy.mock.calls.map((c) => c[0]).join('');
+    expect(output).toMatch(/Unknown command/);
+  });
+
+  it('points init / validate / register at the PY CLI for now', async () => {
+    const code = await runCli(['init']);
+    expect(code).toBe(1);
+    const output = stdoutSpy.mock.calls.map((c) => c[0]).join('');
+    expect(output).toMatch(/not yet implemented/);
+  });
+});
+
+describe('CLI state helpers', () => {
+  let dir: string;
+  let originalHome: string | undefined;
+
+  beforeAll(() => {
+    originalHome = process.env.HOME;
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'armoriq-cli-state-'));
+    process.env.HOME = dir;
+  });
+  afterAll(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns {} when no state file exists', () => {
+    expect(state.loadState()).toEqual({});
+  });
+
+  // Note: saveState/loadState use a path computed at module load time, so
+  // changing HOME after import doesn't redirect them. We just verify the
+  // empty case here — round-trip behavior is exercised manually.
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,138 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseArmorIQConfig,
+  loadArmorIQConfig,
+  resolveEnvReference,
+  resolveEnvReferences,
+  saveArmorIQConfig,
+  ArmorIQConfigError,
+} from '../src/config';
+
+describe('resolveEnvReference', () => {
+  beforeEach(() => {
+    delete process.env.MY_KEY;
+  });
+  it('resolves $VAR', () => {
+    process.env.MY_KEY = 'abc';
+    expect(resolveEnvReference('$MY_KEY')).toBe('abc');
+  });
+  it('resolves ${VAR}', () => {
+    process.env.MY_KEY = 'abc';
+    expect(resolveEnvReference('${MY_KEY}')).toBe('abc');
+  });
+  it('returns "" for an unset var', () => {
+    expect(resolveEnvReference('$DOES_NOT_EXIST_XX')).toBe('');
+  });
+  it('passes literals through unchanged', () => {
+    expect(resolveEnvReference('plain')).toBe('plain');
+    expect(resolveEnvReference('$ with space')).toBe('$ with space');
+  });
+});
+
+describe('parseArmorIQConfig', () => {
+  it('parses a minimal valid config', () => {
+    const cfg = parseArmorIQConfig({
+      version: 'v1',
+      identity: { api_key: 'ak', user_id: 'u', agent_id: 'a' },
+    });
+    expect(cfg.identity.api_key).toBe('ak');
+    expect(cfg.environment).toBe('sandbox');
+    expect(cfg.proxy.url).toContain('armoriq');
+    expect(cfg.intent.ttl_seconds).toBe(300);
+  });
+
+  it('rejects missing identity fields', () => {
+    expect(() =>
+      parseArmorIQConfig({ version: 'v1', identity: { api_key: 'ak' } }),
+    ).toThrow(ArmorIQConfigError);
+  });
+
+  it('rejects an unsupported version', () => {
+    expect(() =>
+      parseArmorIQConfig({
+        version: 'v9',
+        identity: { api_key: 'ak', user_id: 'u', agent_id: 'a' },
+      }),
+    ).toThrow(/version/);
+  });
+
+  it('rejects bearer auth without a token', () => {
+    expect(() =>
+      parseArmorIQConfig({
+        version: 'v1',
+        identity: { api_key: 'ak', user_id: 'u', agent_id: 'a' },
+        mcp_servers: [{ id: 'a', url: 'https://a', auth: { type: 'bearer' } }],
+      }),
+    ).toThrow(/bearer/);
+  });
+
+  it('rejects duplicate mcp_server ids', () => {
+    expect(() =>
+      parseArmorIQConfig({
+        version: 'v1',
+        identity: { api_key: 'ak', user_id: 'u', agent_id: 'a' },
+        mcp_servers: [
+          { id: 'a', url: 'https://a' },
+          { id: 'a', url: 'https://b' },
+        ],
+      }),
+    ).toThrow(/duplicate/);
+  });
+
+  it('normalizes auth: "none" string into the structured form', () => {
+    const cfg = parseArmorIQConfig({
+      version: 'v1',
+      identity: { api_key: 'ak', user_id: 'u', agent_id: 'a' },
+      mcp_servers: [{ id: 'a', url: 'https://a', auth: 'none' }],
+    });
+    expect(cfg.mcp_servers[0].auth).toEqual({ type: 'none' });
+  });
+});
+
+describe('resolveEnvReferences', () => {
+  it('expands $VAR refs through the whole config', () => {
+    process.env.AK = 'ak_test_xyz';
+    process.env.URL_VAR = 'https://foo';
+    process.env.TOKEN_VAR = 't0k';
+    const cfg = parseArmorIQConfig({
+      version: 'v1',
+      identity: { api_key: '$AK', user_id: 'u', agent_id: 'a' },
+      mcp_servers: [
+        { id: 's', url: '$URL_VAR', auth: { type: 'bearer', token: '$TOKEN_VAR' } },
+      ],
+    });
+    const resolved = resolveEnvReferences(cfg);
+    expect(resolved.identity.api_key).toBe('ak_test_xyz');
+    expect(resolved.mcp_servers[0].url).toBe('https://foo');
+    expect(resolved.mcp_servers[0].auth).toEqual({ type: 'bearer', token: 't0k' });
+  });
+});
+
+describe('loadArmorIQConfig + saveArmorIQConfig', () => {
+  it('round-trips a config through YAML', () => {
+    const tmp = path.join(os.tmpdir(), `armoriq-${Date.now()}.yaml`);
+    const cfg = parseArmorIQConfig({
+      version: 'v1',
+      identity: { api_key: 'ak', user_id: 'u', agent_id: 'a' },
+      mcp_servers: [
+        { id: 's', url: 'https://s', auth: { type: 'api_key', api_key: 'k' } },
+      ],
+    });
+    saveArmorIQConfig(cfg, tmp);
+    try {
+      const loaded = loadArmorIQConfig(tmp);
+      expect(loaded.identity).toEqual(cfg.identity);
+      expect(loaded.mcp_servers[0].auth).toEqual({ type: 'api_key', api_key: 'k' });
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+
+  it('throws ArmorIQConfigError when the file is missing', () => {
+    expect(() => loadArmorIQConfig('/tmp/does-not-exist-xx.yaml')).toThrow(
+      ArmorIQConfigError,
+    );
+  });
+});

--- a/tests/e2e/enforcement.e2e.test.ts
+++ b/tests/e2e/enforcement.e2e.test.ts
@@ -1,0 +1,196 @@
+/**
+ * End-to-end tests for the three enforcement outcomes the proxy can return:
+ *   - allow: tool runs, response carries verified result
+ *   - block: PolicyBlockedException is thrown (no tool execution)
+ *   - hold: PolicyHoldException is thrown, delegation flow kicks in
+ *
+ * These tests require a live ArmorIQ deployment. They auto-skip when
+ * ARMORIQ_E2E_API_KEY is not set, so CI runs without the key just
+ * passes the unit tests.
+ *
+ * Required environment to enable:
+ *   ARMORIQ_E2E_API_KEY     ak_test_* or ak_live_* key for the test org
+ *   ARMORIQ_E2E_USER_EMAIL  email of a test user with policies attached
+ *   ARMORIQ_E2E_ALLOW_MCP   MCP whose `noop` tool is allowed by policy
+ *   ARMORIQ_E2E_BLOCK_MCP   MCP whose `denied` tool is blocked by policy
+ *   ARMORIQ_E2E_HOLD_MCP    MCP whose `pay` tool triggers a hold over $1000
+ *   ARMORIQ_E2E_APPROVER    email of a user who can approve the hold
+ *   ARMORIQ_ENV             defaults to staging (override per env)
+ *
+ * The fixtures (org, MCPs, policies) are seeded by the e2e-fixtures
+ * script in conmap-auto/scripts/seed-e2e.ts. See that file for the
+ * exact policy shapes required.
+ */
+
+import { ArmorIQClient } from '../../src/client';
+import {
+  PolicyBlockedException,
+  PolicyHoldException,
+  DelegationException,
+} from '../../src/exceptions';
+
+const E2E_KEY = process.env.ARMORIQ_E2E_API_KEY;
+const E2E_USER = process.env.ARMORIQ_E2E_USER_EMAIL;
+const ALLOW_MCP = process.env.ARMORIQ_E2E_ALLOW_MCP;
+const BLOCK_MCP = process.env.ARMORIQ_E2E_BLOCK_MCP;
+const HOLD_MCP = process.env.ARMORIQ_E2E_HOLD_MCP;
+const APPROVER = process.env.ARMORIQ_E2E_APPROVER;
+
+// jest's `describe.skip` evaluates eagerly, so wrap with a runtime guard.
+const maybeDescribe = E2E_KEY ? describe : describe.skip;
+
+maybeDescribe('E2E: proxy enforcement outcomes (live backend)', () => {
+  let client: ArmorIQClient;
+
+  beforeAll(() => {
+    if (!process.env.ARMORIQ_ENV) process.env.ARMORIQ_ENV = 'staging';
+    client = new ArmorIQClient({
+      apiKey: E2E_KEY!,
+      userId: 'e2e-user',
+      agentId: 'e2e-agent',
+    });
+  });
+
+  describe('allow', () => {
+    it('returns a verified result when the tool is on the allow-list', async () => {
+      if (!ALLOW_MCP) return;
+      const planCapture = client.capturePlan('agent', 'allow probe', {
+        goal: 'allow probe',
+        steps: [
+          {
+            action: 'noop',
+            tool: 'noop',
+            mcp: ALLOW_MCP,
+            params: {},
+            description: 'no-op probe',
+          },
+        ],
+      });
+      const token = await client.getIntentToken(planCapture, undefined, 60);
+      const result = await client.invoke(ALLOW_MCP, 'noop', token, {});
+      expect(result.verified).toBe(true);
+      expect(result.status).toBe('success');
+    }, 30_000);
+  });
+
+  describe('block', () => {
+    it('throws PolicyBlockedException for a denied tool', async () => {
+      if (!BLOCK_MCP) return;
+      const planCapture = client.capturePlan('agent', 'block probe', {
+        goal: 'block probe',
+        steps: [
+          {
+            action: 'denied',
+            tool: 'denied',
+            mcp: BLOCK_MCP,
+            params: {},
+            description: 'should be blocked',
+          },
+        ],
+      });
+
+      // Block can land at one of two layers:
+      //   1. token issuance (POST /iap/sdk/token validates against policy)
+      //   2. invoke (proxy enforces at call time)
+      // Either is a valid outcome — we just need a PolicyBlockedException
+      // somewhere along the path.
+      let thrown: unknown;
+      try {
+        const token = await client.getIntentToken(planCapture, undefined, 60);
+        await client.invoke(BLOCK_MCP, 'denied', token, {});
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeDefined();
+      expect((thrown as Error).name).toMatch(
+        /PolicyBlockedException|PolicyHoldException/,
+      );
+      // We expect block specifically; flag if the policy was misconfigured as hold.
+      if ((thrown as Error).name === 'PolicyHoldException') {
+        console.warn(
+          'block test landed on PolicyHoldException — check that BLOCK_MCP/denied has enforcement: block, not hold',
+        );
+      }
+    }, 30_000);
+  });
+
+  describe('hold', () => {
+    it('throws PolicyHoldException with a delegationId when amount exceeds threshold', async () => {
+      if (!HOLD_MCP || !E2E_USER) return;
+      const planCapture = client.capturePlan('agent', 'hold probe', {
+        goal: 'hold probe',
+        steps: [
+          {
+            action: 'pay',
+            tool: 'pay',
+            mcp: HOLD_MCP,
+            params: { amount: 5000, recipient: 'vendor@example.com' },
+            description: 'over-threshold payment',
+          },
+        ],
+      });
+      const token = await client.getIntentToken(planCapture, undefined, 60);
+
+      let thrown: PolicyHoldException | undefined;
+      try {
+        await client.invokeWithPolicy(
+          HOLD_MCP,
+          'pay',
+          token,
+          { amount: 5000, recipient: 'vendor@example.com' },
+          {
+            userEmail: E2E_USER,
+            // do not auto-wait — we want the bare hold to surface
+            waitForApproval: false,
+          },
+        );
+      } catch (e) {
+        if (e instanceof PolicyHoldException) thrown = e;
+        else throw e;
+      }
+      expect(thrown).toBeInstanceOf(PolicyHoldException);
+      // delegationId surfaces via delegationContext on the hold exception.
+      expect(thrown?.delegationContext?.delegationId).toBeDefined();
+    }, 30_000);
+  });
+
+  describe('delegation lifecycle', () => {
+    it('creates a request, surfaces the pending status, and rejects double-execute', async () => {
+      if (!HOLD_MCP || !E2E_USER || !APPROVER) return;
+      const created = await client.createDelegationRequest({
+        tool: 'pay',
+        action: 'pay',
+        amount: 5000,
+        requesterEmail: E2E_USER,
+        domain: HOLD_MCP,
+        reason: 'e2e: delegation lifecycle',
+      });
+      expect(created.delegationId).toBeDefined();
+      expect(created.status).toMatch(/pending|approved/);
+
+      // Without approval, checkApprovedDelegation should return null.
+      const beforeApproval = await client.checkApprovedDelegation(
+        E2E_USER,
+        'pay',
+        5000,
+      );
+      expect(beforeApproval).toBeNull();
+
+      // markDelegationExecuted on a pending delegation should fail or be a no-op.
+      // The backend currently returns 400 for "not approved"; either is acceptable.
+      let markErr: unknown;
+      try {
+        await client.markDelegationExecuted(E2E_USER, created.delegationId);
+      } catch (e) {
+        markErr = e;
+      }
+      // We don't strictly assert markErr is defined — some backend versions
+      // accept the call as idempotent. The contract we care about is that
+      // the SDK doesn't throw a TypeError or DelegationException with a
+      // garbled message.
+      if (markErr) {
+        expect(markErr).toBeInstanceOf(DelegationException);
+      }
+    }, 30_000);
+  });
+});

--- a/tests/mcp_credentials.test.ts
+++ b/tests/mcp_credentials.test.ts
@@ -1,0 +1,111 @@
+import { ArmorIQClient } from '../src/client';
+import { McpCredential } from '../src/models';
+
+const ENV_KEYS = [
+  'ARMORIQ_MCP_CREDENTIALS',
+  'ARMORIQ_MCP_STRIPE_AUTH_TYPE',
+  'ARMORIQ_MCP_STRIPE_TOKEN',
+  'ARMORIQ_MCP_QB_AUTH_TYPE',
+  'ARMORIQ_MCP_QB_API_KEY',
+  'ARMORIQ_MCP_QB_HEADER_NAME',
+  'ARMORIQ_MCP_BASIC_AUTH_TYPE',
+  'ARMORIQ_MCP_BASIC_USERNAME',
+  'ARMORIQ_MCP_BASIC_PASSWORD',
+];
+
+function clearEnv() {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+describe('ArmorIQClient.resolveMcpCredentials', () => {
+  beforeEach(() => clearEnv());
+  afterAll(() => clearEnv());
+
+  it('returns an empty map when no env or option is set', () => {
+    expect(ArmorIQClient.resolveMcpCredentials()).toEqual({});
+  });
+
+  it('parses ARMORIQ_MCP_CREDENTIALS JSON', () => {
+    process.env.ARMORIQ_MCP_CREDENTIALS = JSON.stringify({
+      Stripe: { authType: 'bearer', token: 'env-json' },
+    });
+    expect(ArmorIQClient.resolveMcpCredentials()).toEqual({
+      Stripe: { authType: 'bearer', token: 'env-json' },
+    });
+  });
+
+  it('reads per-MCP env vars for bearer auth', () => {
+    process.env.ARMORIQ_MCP_STRIPE_AUTH_TYPE = 'bearer';
+    process.env.ARMORIQ_MCP_STRIPE_TOKEN = 'tok';
+    expect(ArmorIQClient.resolveMcpCredentials()).toEqual({
+      STRIPE: { authType: 'bearer', token: 'tok' },
+    });
+  });
+
+  it('reads api_key with optional header name', () => {
+    process.env.ARMORIQ_MCP_QB_AUTH_TYPE = 'api_key';
+    process.env.ARMORIQ_MCP_QB_API_KEY = 'k123';
+    process.env.ARMORIQ_MCP_QB_HEADER_NAME = 'X-Custom';
+    expect(ArmorIQClient.resolveMcpCredentials()).toEqual({
+      QB: { authType: 'api_key', apiKey: 'k123', headerName: 'X-Custom' },
+    });
+  });
+
+  it('reads basic auth from env vars', () => {
+    process.env.ARMORIQ_MCP_BASIC_AUTH_TYPE = 'basic';
+    process.env.ARMORIQ_MCP_BASIC_USERNAME = 'u';
+    process.env.ARMORIQ_MCP_BASIC_PASSWORD = 'p';
+    expect(ArmorIQClient.resolveMcpCredentials()).toEqual({
+      BASIC: { authType: 'basic', username: 'u', password: 'p' },
+    });
+  });
+
+  it('lets constructor option override env-var entries', () => {
+    process.env.ARMORIQ_MCP_STRIPE_AUTH_TYPE = 'bearer';
+    process.env.ARMORIQ_MCP_STRIPE_TOKEN = 'env-tok';
+    const fromOptions = {
+      STRIPE: { authType: 'bearer' as const, token: 'opt-tok' },
+    };
+    expect(ArmorIQClient.resolveMcpCredentials(fromOptions)).toEqual({
+      STRIPE: { authType: 'bearer', token: 'opt-tok' },
+    });
+  });
+
+  it('lets per-MCP env vars override the JSON blob', () => {
+    process.env.ARMORIQ_MCP_CREDENTIALS = JSON.stringify({
+      STRIPE: { authType: 'bearer', token: 'json-tok' },
+    });
+    process.env.ARMORIQ_MCP_STRIPE_AUTH_TYPE = 'bearer';
+    process.env.ARMORIQ_MCP_STRIPE_TOKEN = 'env-tok';
+    expect(ArmorIQClient.resolveMcpCredentials()).toEqual({
+      STRIPE: { authType: 'bearer', token: 'env-tok' },
+    });
+  });
+
+  it('skips silently when the JSON blob is malformed', () => {
+    process.env.ARMORIQ_MCP_CREDENTIALS = 'not-json{';
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(ArmorIQClient.resolveMcpCredentials()).toEqual({});
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('ArmorIQClient.encodeMcpAuthHeader', () => {
+  it('base64-encodes the credential JSON', () => {
+    const cred: McpCredential = { authType: 'bearer', token: 'abc' };
+    const header = ArmorIQClient.encodeMcpAuthHeader(cred);
+    const decoded = Buffer.from(header, 'base64').toString('utf-8');
+    expect(JSON.parse(decoded)).toEqual(cred);
+  });
+
+  it('produces the same digest as the Python SDK for a known input', () => {
+    // PY:  base64.b64encode(json.dumps(cred, separators=(",",":")).encode())
+    // TS:  Buffer.from(JSON.stringify(cred)).toString('base64')
+    // Both must produce the exact same bytes.
+    const cred: McpCredential = { authType: 'bearer', token: 'abc' };
+    expect(ArmorIQClient.encodeMcpAuthHeader(cred)).toBe(
+      Buffer.from('{"authType":"bearer","token":"abc"}').toString('base64'),
+    );
+  });
+});

--- a/tests/plan_builder.test.ts
+++ b/tests/plan_builder.test.ts
@@ -1,0 +1,135 @@
+import {
+  defaultToolNameParser,
+  buildPlanFromToolCalls,
+  hashToolCalls,
+} from '../src/plan_builder';
+
+describe('defaultToolNameParser', () => {
+  it('splits namespaced tool names on the first __ separator', () => {
+    const parse = defaultToolNameParser();
+    expect(parse('Stripe__create_payment')).toEqual({
+      mcp: 'Stripe',
+      action: 'create_payment',
+    });
+  });
+
+  it('preserves __ inside the action portion', () => {
+    const parse = defaultToolNameParser();
+    expect(parse('GitHub__create__pr')).toEqual({
+      mcp: 'GitHub',
+      action: 'create__pr',
+    });
+  });
+
+  it('falls back to defaultMcpName when the name is not namespaced', () => {
+    const parse = defaultToolNameParser('QuickBooks');
+    expect(parse('list_invoices')).toEqual({
+      mcp: 'QuickBooks',
+      action: 'list_invoices',
+    });
+  });
+
+  it('throws when the name is not namespaced and no default is set', () => {
+    const parse = defaultToolNameParser();
+    expect(() => parse('list_invoices')).toThrow(/not namespaced/);
+  });
+
+  it('throws on a malformed prefix (empty mcp or action)', () => {
+    const parse = defaultToolNameParser();
+    expect(() => parse('__create_payment')).toThrow(/malformed/);
+    expect(() => parse('Stripe__')).toThrow(/malformed/);
+  });
+});
+
+describe('buildPlanFromToolCalls', () => {
+  it('produces an SDK-shaped plan from a flat tool-call list', () => {
+    const plan = buildPlanFromToolCalls(
+      [
+        { name: 'Stripe__create_payment', args: { amount: 100 } },
+        { name: 'GitHub__open_pr', args: { title: 'fix' } },
+      ],
+      'do work',
+    );
+    expect(plan).toEqual({
+      goal: 'do work',
+      steps: [
+        {
+          action: 'create_payment',
+          tool: 'create_payment',
+          mcp: 'Stripe',
+          params: { amount: 100 },
+          description: 'Call create_payment on Stripe',
+        },
+        {
+          action: 'open_pr',
+          tool: 'open_pr',
+          mcp: 'GitHub',
+          params: { title: 'fix' },
+          description: 'Call open_pr on GitHub',
+        },
+      ],
+    });
+  });
+
+  it('defaults goal to "agent task" when none is provided', () => {
+    const plan = buildPlanFromToolCalls([{ name: 'A__b' }]);
+    expect(plan.goal).toBe('agent task');
+    expect(plan.steps[0].params).toEqual({});
+  });
+
+  it('respects an explicit defaultMcpName', () => {
+    const plan = buildPlanFromToolCalls(
+      [{ name: 'list_invoices', args: { limit: 5 } }],
+      'list',
+      undefined,
+      'QuickBooks',
+    );
+    expect(plan.steps[0].mcp).toBe('QuickBooks');
+    expect(plan.steps[0].action).toBe('list_invoices');
+  });
+
+  it('accepts a custom parser', () => {
+    const plan = buildPlanFromToolCalls(
+      [{ name: 'stripe.create_payment', args: {} }],
+      undefined,
+      (name) => {
+        const [mcp, action] = name.split('.');
+        return { mcp, action };
+      },
+    );
+    expect(plan.steps[0].mcp).toBe('stripe');
+    expect(plan.steps[0].action).toBe('create_payment');
+  });
+});
+
+describe('hashToolCalls', () => {
+  it('returns a 64-char SHA-256 hex digest', () => {
+    const h = hashToolCalls([{ name: 'A__b', args: { x: 1 } }]);
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is stable across calls with the same input', () => {
+    const calls = [{ name: 'A__b', args: { x: 1 } }];
+    expect(hashToolCalls(calls)).toBe(hashToolCalls(calls));
+  });
+
+  it('changes when the args change', () => {
+    const a = hashToolCalls([{ name: 'A__b', args: { x: 1 } }]);
+    const b = hashToolCalls([{ name: 'A__b', args: { x: 2 } }]);
+    expect(a).not.toBe(b);
+  });
+
+  it('treats missing args the same as empty args (PY parity)', () => {
+    expect(hashToolCalls([{ name: 'A__b' }])).toBe(
+      hashToolCalls([{ name: 'A__b', args: {} }]),
+    );
+  });
+
+  it('uses the same canonical form Python emits (parity guard)', () => {
+    // PY:  json.dumps([{"name":"A__b","args":{"x":1}}], separators=(",",":"))
+    // TS:  JSON.stringify([{name:"A__b",args:{x:1}}])
+    // Both must produce the exact same bytes for the digests to agree.
+    const canonical = JSON.stringify([{ name: 'A__b', args: { x: 1 } }]);
+    expect(canonical).toBe('[{"name":"A__b","args":{"x":1}}]');
+  });
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,180 @@
+import { ArmorIQClient } from '../src/client';
+import { ArmorIQSession } from '../src/session';
+import { IntentToken } from '../src/models';
+
+// Sessions reach into client._sessionInternals() for HTTP work, but several
+// methods (enforceLocal, hashing, plan capture, reset) are pure and don't
+// hit the network. We unit-test those without booting a real client.
+
+function makeClient(): ArmorIQClient {
+  process.env.ARMORIQ_API_KEY = 'ak_test_unit-' + Date.now();
+  process.env.USER_ID = 'unit-user';
+  process.env.AGENT_ID = 'unit-agent';
+  // Skip the validateApiKey ping by pretending to be ArmorClaw — it short-circuits.
+  process.env.ARMORIQ_API_KEY = 'ak_claw_unit-' + Date.now();
+  return new ArmorIQClient();
+}
+
+function tokenWithPolicy(policyValidation?: any, policySnapshot?: any[]): IntentToken {
+  return {
+    tokenId: 't',
+    planHash: 'h',
+    signature: 'sig',
+    issuedAt: Date.now() / 1000,
+    expiresAt: Date.now() / 1000 + 3600,
+    policy: {},
+    compositeIdentity: 'c',
+    stepProofs: [],
+    totalSteps: 0,
+    rawToken: {},
+    policyValidation,
+    policySnapshot,
+  };
+}
+
+describe('ArmorIQSession.enforceLocal', () => {
+  let client: ArmorIQClient;
+  beforeAll(() => {
+    client = makeClient();
+  });
+
+  it('blocks before startPlan() is called', () => {
+    const s = new ArmorIQSession(client);
+    const r = s.enforceLocal('Stripe__create_payment', {});
+    expect(r.allowed).toBe(false);
+    expect(r.action).toBe('block');
+    expect(r.reason).toMatch(/No intent token/);
+  });
+
+  it('blocks tools not declared in the captured plan', () => {
+    const s = new ArmorIQSession(client);
+    // Inject a token + declared tools without going through startPlan (HTTP).
+    (s as any).currentToken = tokenWithPolicy();
+    (s as any).declaredTools = new Set(['Stripe__create_payment', 'create_payment']);
+    (s as any).mcpByAction = new Map([['create_payment', 'Stripe']]);
+
+    const r = s.enforceLocal('Other__different_tool', {});
+    expect(r.allowed).toBe(false);
+    expect(r.action).toBe('block');
+    expect(r.reason).toMatch(/tool-not-in-plan/);
+  });
+
+  it('allows declared tools when policy snapshot has wildcard allow', () => {
+    const s = new ArmorIQSession(client);
+    (s as any).currentToken = tokenWithPolicy({}, [
+      { policyName: 'p', memberRule: { allowedTools: ['*'] } },
+    ]);
+    (s as any).declaredTools = new Set(['Stripe__create_payment', 'create_payment']);
+    (s as any).mcpByAction = new Map([['create_payment', 'Stripe']]);
+
+    const r = s.enforceLocal('Stripe__create_payment', {});
+    expect(r.allowed).toBe(true);
+    expect(r.action).toBe('allow');
+    expect(r.matchedPolicy).toBe('p');
+  });
+
+  it('blocks when denied_tools contains the action', () => {
+    const s = new ArmorIQSession(client);
+    (s as any).currentToken = tokenWithPolicy(
+      { denied_tools: ['create_payment'] },
+      [{ policyName: 'p', memberRule: { allowedTools: ['*'] } }],
+    );
+    (s as any).declaredTools = new Set(['Stripe__create_payment', 'create_payment']);
+    (s as any).mcpByAction = new Map([['create_payment', 'Stripe']]);
+
+    const r = s.enforceLocal('Stripe__create_payment', {});
+    expect(r.allowed).toBe(false);
+    expect(r.action).toBe('block');
+  });
+
+  it('returns hold when amountThreshold.requireApprovalAbove is exceeded', () => {
+    const s = new ArmorIQSession(client);
+    (s as any).currentToken = tokenWithPolicy({}, [
+      {
+        policyName: 'p',
+        memberRule: {
+          allowedTools: ['*'],
+          financialRule: {
+            amountThreshold: { requireApprovalAbove: 1000, currency: 'USD' },
+          },
+        },
+      },
+    ]);
+    (s as any).declaredTools = new Set(['Stripe__create_payment', 'create_payment']);
+    (s as any).mcpByAction = new Map([['create_payment', 'Stripe']]);
+
+    const r = s.enforceLocal('Stripe__create_payment', { amount: 5000 });
+    expect(r.action).toBe('hold');
+    expect(r.matchedPolicy).toBe('p');
+  });
+
+  it('returns block when amountThreshold.maxPerTransaction is exceeded', () => {
+    const s = new ArmorIQSession(client);
+    (s as any).currentToken = tokenWithPolicy({}, [
+      {
+        policyName: 'p',
+        memberRule: {
+          allowedTools: ['*'],
+          financialRule: {
+            amountThreshold: { maxPerTransaction: 1000, currency: 'USD' },
+          },
+        },
+      },
+    ]);
+    (s as any).declaredTools = new Set(['Stripe__create_payment', 'create_payment']);
+    (s as any).mcpByAction = new Map([['create_payment', 'Stripe']]);
+
+    const r = s.enforceLocal('Stripe__create_payment', { amount: 5000 });
+    expect(r.action).toBe('block');
+  });
+
+  it('blocks when the token is expired', () => {
+    const s = new ArmorIQSession(client);
+    const expired = tokenWithPolicy();
+    expired.expiresAt = Date.now() / 1000 - 1;
+    (s as any).currentToken = expired;
+    (s as any).declaredTools = new Set(['Stripe__create_payment']);
+    const r = s.enforceLocal('Stripe__create_payment', {});
+    expect(r.action).toBe('block');
+    expect(r.reason).toBe('token-expired');
+  });
+});
+
+describe('ArmorIQSession.check (mode dispatch, pure path)', () => {
+  let client: ArmorIQClient;
+  beforeAll(() => {
+    client = makeClient();
+  });
+
+  it('downgrades hold to block in local mode', async () => {
+    const s = new ArmorIQSession(client, { mode: 'local' });
+    (s as any).currentToken = tokenWithPolicy({}, [
+      {
+        policyName: 'p',
+        memberRule: {
+          allowedTools: ['*'],
+          financialRule: { amountThreshold: { requireApprovalAbove: 100 } },
+        },
+      },
+    ]);
+    (s as any).declaredTools = new Set(['Stripe__create_payment', 'create_payment']);
+    (s as any).mcpByAction = new Map([['create_payment', 'Stripe']]);
+    const r = await s.check('Stripe__create_payment', { amount: 500 });
+    expect(r.action).toBe('block');
+    expect(r.reason).toMatch(/ARMORIQ_MODE=proxy/);
+  });
+});
+
+describe('ArmorIQSession.reset', () => {
+  it('clears cached plan + token state', () => {
+    const client = makeClient();
+    const s = new ArmorIQSession(client);
+    (s as any).currentToken = tokenWithPolicy();
+    (s as any).currentPlanHash = 'h';
+    (s as any).declaredTools = new Set(['t']);
+    s.reset();
+    expect(s.currentTokenValue).toBeUndefined();
+    expect((s as any).currentPlanHash).toBeUndefined();
+    expect((s as any).declaredTools.size).toBe(0);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary

Brings \`dev\` up to \`main\` after the full parity port. Preserves the dev-side staging URL flag (\`ARMORIQ_ENV = 'staging'\` in \`src/_build_env.ts\`) so the only diff between branches stays the URL constant.

This bundles two main commits:

- [\`179418f\`](https://github.com/armoriq/armoriq-sdk-customer-ts/commit/179418f) — plan_builder + ToolCall/McpCredential models + MCP cred header (was open as #43, now superseded)
- [\`be4b1dc\`](https://github.com/armoriq/armoriq-sdk-customer-ts/commit/be4b1dc) — sessions, bootstrap, forUser, fromConfig, full CLI, Google ADK integration

## What's new on dev

- **Sessions** (\`src/session.ts\`): three enforcement modes (local / sdk / proxy), hold→block downgrade in local, delegation kickoff on hold
- **\`ArmorIQClient\`**: \`bootstrap\`, \`refreshBootstrap\`, \`resolveUser\`, \`invalidateUser\`, \`forUser\` (returns \`ArmorIQUserScope\`), \`startSession\`, \`fromConfig\`
- **Config** (\`src/config.ts\`): \`armoriq.yaml\` schema mirroring PY config.py + \`\$VAR\` env expansion + round-trip save
- **CLI** (\`src/cli/\`): \`armoriq login | logout | whoami | orgs | switch-org | status | logs | keys list/revoke/prune\`, wired as \`bin: { armoriq }\` in package.json. \`init / validate / register\` stubbed with a pointer to PY CLI (need MCP discovery, follow-up).
- **Google ADK integration** (\`src/integrations/google_adk.ts\`): \`ArmorIQADK\` factory + per-request bundle that installs the three lifecycle callbacks (after_model / before_tool / after_tool) on a duck-typed agent. 30-min hold poll with 3→15s exponential backoff matches PY.
- **Models**: \`ToolCall\`, \`McpCredential\`, \`McpCredentialMap\` exported (PY-compatible JSON shape so \`ARMORIQ_MCP_CREDENTIALS\` env var works in both SDKs).
- **MCP credential resolution**: env JSON < per-MCP env < ctor option, base64-injected as \`X-Armoriq-MCP-Auth\` on \`invoke()\`.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 50 unit tests pass, 4 E2E auto-skip without \`ARMORIQ_E2E_API_KEY\`
- [x] Verified \`src/_build_env.ts\` still says \`ARMORIQ_ENV = 'staging'\` after the cherry-pick
- [x] Verified \`dist/cli/index.js help\` runs and shows the command surface
- [ ] (Reviewer) Smoke the CLI on staging:
  - \`node dist/cli/index.js login --org <staging-org>\`
  - \`node dist/cli/index.js orgs\`
  - \`node dist/cli/index.js keys list\`
- [ ] (Reviewer) E2E run against staging with \`ARMORIQ_E2E_API_KEY\` set — see header doc-comment in \`tests/e2e/enforcement.e2e.test.ts\` for fixture env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)