### PR TITLE
sync: main → dev (retry/idempotency port — last cross-SDK gap)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -80,6 +80,7 @@ export class ArmorIQClient {
   private contextId: string;
   private apiKey: string;
   private timeout: number;
+  private maxRetries: number;
   private verifySsl: boolean;
   private httpClient: AxiosInstance;
   private tokenCache: Map<string, IntentToken>;
@@ -179,6 +180,7 @@ export class ArmorIQClient {
 
     this.proxyEndpoints = options.proxyEndpoints || {};
     this.timeout = options.timeout || 30000;
+    this.maxRetries = (options as any).maxRetries ?? 3;
     this.verifySsl = options.verifySsl ?? true;
 
     // Initialize HTTP client
@@ -426,6 +428,66 @@ export class ArmorIQClient {
     return Buffer.from(JSON.stringify(cred), 'utf-8').toString('base64');
   }
 
+  // ─── Retry helpers ─────────────────────────────────────────────────
+  // Mirrors armoriq_sdk/client.py:_retry_post. Exponential backoff
+  // (1s → 4s capped) on 5xx + network errors only — 4xx passes through
+  // unchanged so callers can still distinguish policy denials from
+  // transport flakes. The same Idempotency-Key is reused across retries
+  // so the backend can dedupe.
+
+  private shouldRetry(status: number | undefined): boolean {
+    if (status === undefined) return true; // network error
+    return status >= 500;
+  }
+
+  /**
+   * POST with exponential backoff. Reuses the same Idempotency-Key
+   * across retries so the backend can dedupe on its side.
+   * @internal
+   */
+  async _retryPost(
+    url: string,
+    body: unknown,
+    options: {
+      headers?: Record<string, string>;
+      timeout?: number;
+      idempotencyKey?: string;
+    } = {},
+  ): Promise<import('axios').AxiosResponse> {
+    const merged: Record<string, string> = { ...(options.headers ?? {}) };
+    if (options.idempotencyKey && !merged['Idempotency-Key']) {
+      merged['Idempotency-Key'] = options.idempotencyKey;
+    }
+    const attempts = Math.max(1, this.maxRetries + 1);
+    let lastErr: unknown;
+    let lastResponse: import('axios').AxiosResponse | undefined;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        const response = await this.httpClient.post(url, body, {
+          headers: merged,
+          timeout: options.timeout ?? this.timeout,
+        });
+        if (!this.shouldRetry(response.status)) return response;
+        lastResponse = response;
+      } catch (e: any) {
+        // axios throws on network errors when validateStatus doesn't catch them;
+        // ECONNREFUSED / ETIMEDOUT / socket-hangup all surface as Error here.
+        const code = e?.code;
+        if (code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'ECONNRESET' || !e?.response) {
+          lastErr = e;
+        } else {
+          throw e;
+        }
+      }
+      if (i < attempts - 1) {
+        const backoff = Math.min(1000 * 2 ** i, 4000);
+        await new Promise((r) => setTimeout(r, backoff));
+      }
+    }
+    if (lastResponse) return lastResponse;
+    throw lastErr ?? new Error('retry loop exited without a result');
+  }
+
   /**
    * Validate API key with the proxy server.
    */
@@ -528,9 +590,12 @@ export class ArmorIQClient {
     };
 
     try {
-      const response = await this.httpClient.post(`${this.backendEndpoint}/iap/sdk/token`, payload, {
+      // Token issuance is idempotent on the backend (planHash-keyed),
+      // so retrying a 5xx with the same Idempotency-Key is safe.
+      const response = await this._retryPost(`${this.backendEndpoint}/iap/sdk/token`, payload, {
         headers: { 'X-API-Key': this.apiKey },
         timeout: 30000,
+        idempotencyKey: crypto.randomBytes(16).toString('hex'),
       });
 
       if (response.status >= 400) {
@@ -1168,12 +1233,18 @@ export class ArmorIQClient {
 
   /**
    * Mark a delegation as executed.
+   *
+   * Idempotent on the backend (delegationId-keyed), so a stable
+   * Idempotency-Key derived from the delegation_id is safe to retry.
    */
   async markDelegationExecuted(userEmail: string, delegationId: string): Promise<void> {
-    await this.httpClient.post(
+    await this._retryPost(
       `${this.backendEndpoint}/delegation/mark-executed`,
       { delegationId },
-      { headers: { 'X-API-Key': this.apiKey, 'X-User-Email': userEmail } },
+      {
+        headers: { 'X-API-Key': this.apiKey, 'X-User-Email': userEmail },
+        idempotencyKey: `mark-exec:${delegationId}`,
+      },
     );
   }
 
@@ -1186,14 +1257,20 @@ export class ArmorIQClient {
 
   /**
    * Update an intent plan's status.
+   *
+   * Status transitions are idempotent — retrying with the same
+   * `planId:status` key is safe.
    * Valid statuses: 'active', 'completed', 'failed', 'expired'
    */
   async updatePlanStatus(planId: string, status: string): Promise<void> {
     try {
-      await this.httpClient.post(
+      await this._retryPost(
         `${this.backendEndpoint}/iap/plans/${planId}/status`,
         { status },
-        { headers: { 'X-API-Key': this.apiKey } },
+        {
+          headers: { 'X-API-Key': this.apiKey },
+          idempotencyKey: `plan-status:${planId}:${status}`,
+        },
       );
       console.log(`Plan ${planId} status updated to ${status}`);
     } catch (error: any) {

--- a/tests/retry_idempotency.test.ts
+++ b/tests/retry_idempotency.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the retry/idempotency layer on ArmorIQClient (TS port of
+ * armoriq-sdk-customer/tests/test_retry_idempotency.py).
+ *
+ * Covers:
+ *   - 5xx triggers retry, 4xx does not
+ *   - Network errors trigger retry
+ *   - Idempotency-Key is reused across retries
+ *   - maxRetries=0 disables retry entirely
+ *   - Stable Idempotency-Key for delegation/mark-executed and plan/status
+ */
+
+import { ArmorIQClient } from '../src/client';
+
+function makeClient(maxRetries: number = 3): ArmorIQClient {
+  process.env.ARMORIQ_API_KEY = 'ak_claw_test-retry-' + Date.now();
+  process.env.USER_ID = 'unit-user';
+  process.env.AGENT_ID = 'unit-agent';
+  // ak_claw_ skips the validateApiKey ping during construction.
+  return new ArmorIQClient({ maxRetries } as any);
+}
+
+function fakeResponse(status: number, data: unknown = {}) {
+  return { status, data, headers: {}, statusText: '', config: {} } as any;
+}
+
+describe('ArmorIQClient._retryPost', () => {
+  it('retries on 5xx and reuses the same Idempotency-Key', async () => {
+    const client = makeClient();
+    const calls: Array<{ url: string; key: string | undefined }> = [];
+    let attempt = 0;
+    (client as any).httpClient.post = jest.fn(async (url: string, _body: any, opts: any) => {
+      calls.push({ url, key: opts.headers?.['Idempotency-Key'] });
+      attempt += 1;
+      return attempt < 3 ? fakeResponse(503) : fakeResponse(200, { ok: true });
+    });
+    // Skip the backoff sleeps so the test is fast.
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb: any) => {
+      cb();
+      return 0 as any;
+    });
+
+    const r = await (client as any)._retryPost('https://x/y', {}, { idempotencyKey: 'key1' });
+    expect(r.status).toBe(200);
+    expect(calls).toHaveLength(3);
+    expect(calls.every((c) => c.key === 'key1')).toBe(true);
+    (global.setTimeout as any).mockRestore?.();
+  });
+
+  it('does not retry on 4xx', async () => {
+    const client = makeClient();
+    let calls = 0;
+    (client as any).httpClient.post = jest.fn(async () => {
+      calls += 1;
+      return fakeResponse(400, { message: 'bad request' });
+    });
+    const r = await (client as any)._retryPost('https://x/y', {});
+    expect(r.status).toBe(400);
+    expect(calls).toBe(1);
+  });
+
+  it('retries on network errors (no .response on the thrown error)', async () => {
+    const client = makeClient();
+    let attempt = 0;
+    (client as any).httpClient.post = jest.fn(async () => {
+      attempt += 1;
+      if (attempt < 2) {
+        const err: any = new Error('connect ECONNREFUSED');
+        err.code = 'ECONNREFUSED';
+        throw err;
+      }
+      return fakeResponse(200);
+    });
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb: any) => {
+      cb();
+      return 0 as any;
+    });
+
+    const r = await (client as any)._retryPost('https://x/y', {});
+    expect(r.status).toBe(200);
+    expect(attempt).toBe(2);
+    (global.setTimeout as any).mockRestore?.();
+  });
+
+  it('maxRetries=0 disables retry entirely', async () => {
+    const client = makeClient(0);
+    let calls = 0;
+    (client as any).httpClient.post = jest.fn(async () => {
+      calls += 1;
+      return fakeResponse(503);
+    });
+    const r = await (client as any)._retryPost('https://x/y', {});
+    expect(r.status).toBe(503);
+    expect(calls).toBe(1);
+  });
+});
+
+describe('Stable Idempotency-Key on hot paths', () => {
+  it('markDelegationExecuted uses mark-exec:<id>', async () => {
+    const client = makeClient();
+    const captured: Array<any> = [];
+    (client as any).httpClient.post = jest.fn(async (url: string, body: any, opts: any) => {
+      captured.push({ url, body, headers: opts.headers });
+      return fakeResponse(200);
+    });
+    await client.markDelegationExecuted('u@example.com', 'deleg-123');
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toMatch(/\/delegation\/mark-executed$/);
+    expect(captured[0].headers['Idempotency-Key']).toBe('mark-exec:deleg-123');
+    expect(captured[0].headers['X-User-Email']).toBe('u@example.com');
+    expect(captured[0].body).toEqual({ delegationId: 'deleg-123' });
+  });
+
+  it('updatePlanStatus uses plan-status:<id>:<status>', async () => {
+    const client = makeClient();
+    const captured: Array<any> = [];
+    (client as any).httpClient.post = jest.fn(async (url: string, _body: any, opts: any) => {
+      captured.push({ url, headers: opts.headers });
+      return fakeResponse(200);
+    });
+    await client.updatePlanStatus('plan-9', 'completed');
+    expect(captured).toHaveLength(1);
+    expect(captured[0].headers['Idempotency-Key']).toBe('plan-status:plan-9:completed');
+  });
+
+  it('completePlan delegates to updatePlanStatus(plan, "completed")', async () => {
+    const client = makeClient();
+    const seen: string[] = [];
+    (client as any).httpClient.post = jest.fn(async (_url: string, body: any) => {
+      seen.push(body.status);
+      return fakeResponse(200);
+    });
+    await client.completePlan('plan-x');
+    expect(seen).toEqual(['completed']);
+  });
+});


### PR DESCRIPTION
## Summary

Brings \`dev\` up to \`main\` for the TS-side \`_retryPost\` + \`maxRetries\` port that matches the layer PY shipped in #22. Preserves the dev-side staging flag (\`ARMORIQ_ENV = 'staging'\` in \`src/_build_env.ts\`) so the only diff between branches stays the URL constant.

## What's in this commit

- **\`maxRetries\`** constructor option (default 3)
- **\`_retryPost(url, body, { headers, timeout, idempotencyKey })\`** helper
  - Exponential backoff (1s → 4s capped) on **5xx** + network errors only
  - **4xx** passes through unchanged so callers can still distinguish policy denials from transport flakes
  - Same Idempotency-Key reused across retries so the backend can dedupe
- **Wired into:**
  - \`getIntentToken\` → \`POST /iap/sdk/token\` (random per-call key)
  - \`markDelegationExecuted\` → \`POST /delegation/mark-executed\` (stable: \`mark-exec:<id>\`)
  - \`updatePlanStatus\` / \`completePlan\` → \`POST /iap/plans/{id}/status\` (stable: \`plan-status:<id>:<status>\`)
- \`createDelegationRequest\` already had a per-call Idempotency-Key (#23) — left unchanged.

## Test plan

- [x] 57 unit tests pass (7 new in \`tests/retry_idempotency.test.ts\` covering 5xx-retry, 4xx-no-retry, ECONNREFUSED-retry, maxRetries=0 disable, stable-key contract on each hot path)
- [x] \`npm run build\` clean
- [x] Verified \`src/_build_env.ts\` still says \`ARMORIQ_ENV = 'staging'\` after the cherry-pick

## Closes the last cross-SDK gap

This was the only remaining drift after the parity round: PY had \`_retry_post\` + per-hot-path Idempotency-Key, TS had only one Idempotency-Key on \`createDelegationRequest\`. Now both SDKs ship the same retry semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)