### PR TITLE
chore: bump version to 0.3.0 (@armoriq/sdk-dev)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,23 @@
 {
-  "name": "@armoriq/sdk",
-  "version": "0.2.15",
+  "name": "@armoriq/sdk-dev",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@armoriq/sdk",
-      "version": "0.2.15",
+      "name": "@armoriq/sdk-dev",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@types/js-yaml": "^4.0.9",
         "axios": "^1.7.0",
         "js-yaml": "^4.1.1"
       },
+      "bin": {
+        "armoriq": "dist/cli/index.js"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
@@ -1314,6 +1317,7 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@armoriq/sdk",
-  "version": "0.2.15",
+  "name": "@armoriq/sdk-dev",
+  "version": "0.3.0",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -185,7 +185,7 @@ export class ArmorIQClient {
 
     // Initialize HTTP client
     const headers: Record<string, string> = {
-      'User-Agent': `ArmorIQ-SDK-TS/0.2.6 (agent=${this.agentId})`,
+      'User-Agent': `ArmorIQ-SDK-TS/0.3.0 (agent=${this.agentId})`,
     };
     if (this.apiKey) {
       headers['Authorization'] = `Bearer ${this.apiKey}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,6 @@ export {
   DEFAULT_PROXY_URL,
 } from './config';
 
-export const VERSION = '0.2.6';
+export const VERSION = '0.3.0';
 export const AUTHOR = 'ArmorIQ Team';
 export const EMAIL = 'license@armoriq.io';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * tool invocation with built-in security.
  * 
  * @author ArmorIQ Team <license@armoriq.io>
- * @version 0.2.6
+ * @version 0.3.0
  */
 
 export { ArmorIQClient, ArmorIQUserScope } from './client';


### PR DESCRIPTION
Dev release matching @armoriq/sdk@0.3.0 on main, with staging URLs baked into _build_env.ts.