### PR TITLE
fix(adk): match @google/adk@0.6.x callback shape; bump to 0.3.1 (@armoriq/sdk-dev)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@armoriq/sdk-dev",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -185,7 +185,7 @@ export class ArmorIQClient {
 
     // Initialize HTTP client
     const headers: Record<string, string> = {
-      'User-Agent': `ArmorIQ-SDK-TS/0.3.0 (agent=${this.agentId})`,
+      'User-Agent': `ArmorIQ-SDK-TS/0.3.1 (agent=${this.agentId})`,
     };
     if (this.apiKey) {
       headers['Authorization'] = `Bearer ${this.apiKey}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * tool invocation with built-in security.
  * 
  * @author ArmorIQ Team <license@armoriq.io>
- * @version 0.3.0
+ * @version 0.2.6
  */
 
 export { ArmorIQClient, ArmorIQUserScope } from './client';
@@ -77,6 +77,6 @@ export {
   DEFAULT_PROXY_URL,
 } from './config';
 
-export const VERSION = '0.3.0';
+export const VERSION = '0.3.1';
 export const AUTHOR = 'ArmorIQ Team';
 export const EMAIL = 'license@armoriq.io';

--- a/src/integrations/google_adk.ts
+++ b/src/integrations/google_adk.ts
@@ -49,6 +49,10 @@ export interface ArmorIQADKOptions {
   validitySeconds?: number;
   mode?: SessionMode;
   llm?: string;
+  /** Per-call HTTP timeout for `enforceSdk` / `enforce` checks (ms). Default 10000. */
+  checkTimeoutMs?: number;
+  /** HTTP timeout for `report()` audit POSTs (ms). Default 5000. */
+  reportTimeoutMs?: number;
 }
 
 /**
@@ -70,6 +74,8 @@ export class ArmorIQADK {
   public readonly llm: string;
   public readonly validitySeconds: number;
   public readonly defaultMcpName?: string;
+  public readonly checkTimeoutMs?: number;
+  public readonly reportTimeoutMs?: number;
   private customParser?: ToolNameParser;
   private bootstrapData?: Record<string, any>;
 
@@ -88,6 +94,8 @@ export class ArmorIQADK {
     this.validitySeconds = opts.validitySeconds ?? 300;
     this.mode = opts.mode ?? 'sdk';
     this.llm = opts.llm ?? 'agent';
+    this.checkTimeoutMs = opts.checkTimeoutMs;
+    this.reportTimeoutMs = opts.reportTimeoutMs;
   }
 
   async bootstrap(): Promise<Record<string, any>> {
@@ -183,15 +191,22 @@ export class ArmorIQADKBundle {
         llm: this.factory.llm,
         toolNameParser: this.parser,
         defaultMcpName: this.factory.defaultMcpName,
+        checkTimeoutMs: this.factory.checkTimeoutMs,
+        reportTimeoutMs: this.factory.reportTimeoutMs,
       };
       this.session = this.scope.startSession(opts);
     }
     return this.session;
   }
 
-  private async afterModel(_callbackContext: any, llmResponse: any): Promise<unknown> {
+  // ADK 0.6.x calls each lifecycle callback with a single object param —
+  // see node_modules/@google/adk/dist/types/agents/llm_agent.d.ts.
+  // Older shapes (positional args) silently produced `args[1] === undefined`
+  // and `tool === [object Object]`, which made the SDK fail-open.
+  private async afterModel(params: { context?: any; response?: any }): Promise<unknown> {
     try {
       if (this.planMinted) return null;
+      const llmResponse = params?.response;
       const parts = llmResponse?.content?.parts ?? [];
       const toolCalls: ToolCall[] = [];
       for (const p of parts) {
@@ -210,7 +225,13 @@ export class ArmorIQADKBundle {
     return null;
   }
 
-  private async beforeTool(tool: any, args: any, _toolContext?: any): Promise<unknown> {
+  private async beforeTool(params: {
+    tool: any;
+    args: any;
+    context?: any;
+  }): Promise<unknown> {
+    const tool = params?.tool;
+    const args = params?.args;
     const toolName: string = tool?.name ?? String(tool);
     try {
       const decision = await this.ensureSession().check(toolName, args ?? {}, this.userEmail);
@@ -306,7 +327,15 @@ export class ArmorIQADKBundle {
     return null;
   }
 
-  private async afterTool(tool: any, args: any, _toolContext: any, toolResponse: any): Promise<unknown> {
+  private async afterTool(params: {
+    tool: any;
+    args: any;
+    context?: any;
+    response: any;
+  }): Promise<unknown> {
+    const tool = params?.tool;
+    const args = params?.args;
+    const toolResponse = params?.response;
     const toolName: string = tool?.name ?? String(tool);
     try {
       if (this.blockedTools.has(toolName)) {
@@ -339,10 +368,11 @@ export class ArmorIQADKBundle {
       beforeToolCallback: agent.beforeToolCallback,
       afterToolCallback: agent.afterToolCallback,
     };
-    agent.afterModelCallback = (...args: any[]) => this.afterModel(args[0], args[1]);
-    agent.beforeToolCallback = (tool: any, args: any, ctx?: any) => this.beforeTool(tool, args, ctx);
-    agent.afterToolCallback = (tool: any, args: any, ctx?: any, response?: any) =>
-      this.afterTool(tool, args, ctx, response);
+    // ADK 0.6.x callback shape: a single object containing all params.
+    // See dist/types/agents/llm_agent.d.ts in @google/adk.
+    agent.afterModelCallback = (params: any) => this.afterModel(params);
+    agent.beforeToolCallback = (params: any) => this.beforeTool(params);
+    agent.afterToolCallback = (params: any) => this.afterTool(params);
     return this;
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -31,6 +31,16 @@ export interface SessionOptions {
   validitySeconds?: number;
   llm?: string;
   mode?: SessionMode;
+  /**
+   * Per-call HTTP timeout for `enforceSdk` and `enforce` (proxy) checks.
+   * Default 10000ms. Bump for staging deployments where the backend is
+   * slow under load (e.g. public-IP DB without connection pooling).
+   */
+  checkTimeoutMs?: number;
+  /**
+   * HTTP timeout for `report()` audit POSTs. Default 5000ms.
+   */
+  reportTimeoutMs?: number;
 }
 
 export interface EnforceResult {
@@ -60,6 +70,8 @@ export class ArmorIQSession {
   private validitySeconds: number;
   private llm: string;
   private mode: SessionMode;
+  private checkTimeoutMs: number;
+  private reportTimeoutMs: number;
   private stepIndex = 0;
   private currentPlanHash?: string;
   private currentToken?: IntentToken;
@@ -74,6 +86,8 @@ export class ArmorIQSession {
     this.validitySeconds = o.validitySeconds ?? 3600;
     this.llm = o.llm ?? 'agent';
     this.mode = o.mode ?? 'local';
+    this.checkTimeoutMs = o.checkTimeoutMs ?? 10000;
+    this.reportTimeoutMs = o.reportTimeoutMs ?? 5000;
   }
 
   // ─── Plan capture ──────────────────────────────────────────────
@@ -279,7 +293,7 @@ export class ArmorIQSession {
         },
         {
           headers: { 'X-API-Key': internals.apiKey, 'Content-Type': 'application/json' },
-          timeout: 10000,
+          timeout: this.checkTimeoutMs,
         },
       );
       const data = response.data ?? {};
@@ -356,7 +370,7 @@ export class ArmorIQSession {
         payload,
         {
           headers: { 'X-API-Key': internals.apiKey, 'Content-Type': 'application/json' },
-          timeout: 10000,
+          timeout: this.checkTimeoutMs,
         },
       );
       if (response.status === 403) {
@@ -458,7 +472,7 @@ export class ArmorIQSession {
         },
         {
           headers: { 'X-API-Key': internals.apiKey, 'Content-Type': 'application/json' },
-          timeout: 5000,
+          timeout: this.reportTimeoutMs,
         },
       );
     } catch (e) {


### PR DESCRIPTION
## Summary

Mirrors [\`@armoriq/sdk@0.3.1\`](https://www.npmjs.com/package/@armoriq/sdk/v/0.3.1) (already published from \`main\`) onto \`dev\`. Preserves the staging URL flag and \`@armoriq/sdk-dev\` package name.

The published \`@armoriq/sdk-dev@0.3.1\` is already live on npm — this PR aligns the branch state with what got published.

## What's fixed

**Bug 1 — ADK 0.6.x callback shape mismatch.** Our integration was wired with positional arguments from an older ADK shape. ADK 0.6.x calls every lifecycle callback with a single object param (verified in \`@google/adk/dist/types/agents/llm_agent.d.ts\`):

\`\`\`ts
afterModelCallback   ({ context, response })
beforeToolCallback   ({ tool, args, context })
afterToolCallback    ({ tool, args, context, response })
\`\`\`

Result before fix: \`afterModel\` reads \`response\` from \`args[1]\` which is undefined → \`startPlan()\` never runs → \`beforeTool\` reads \`tool.name\` from \`{tool,args,context}\` which has no \`.name\` → falls to \`String(tool)\` = \`"[object Object]"\` → \`session.check\` throws → catch silently warns → ADK runs the tool. **Policy enforcement was failing-open.**

**Bug 2 — Hardcoded HTTP timeouts.** \`session.ts\` had \`timeout: 5000\` (report) and \`timeout: 10000\` (enforce/check) baked in. Against staging conmap-auto with public-IP DB, these regularly timed out. Now configurable via \`SessionOptions.{checkTimeoutMs, reportTimeoutMs}\` and surfaced through \`ArmorIQADKOptions\`:

\`\`\`ts
new ArmorIQADK({ apiKey, reportTimeoutMs: 30000, checkTimeoutMs: 30000 })
\`\`\`

## Test plan

- [x] 57 unit tests pass
- [x] \`npm run build\` clean
- [x] Verified \`src/_build_env.ts\` still says \`ARMORIQ_ENV = 'staging'\`
- [x] Diff vs \`main\` is only URL flag + package name + lockfile (the parity-convention 1-line difference)
- [ ] (Reviewer) Smoke-test against \`ihealth-agent\` allow / block / hold / approve flows after \`npm install\` picks up \`@armoriq/sdk-dev@0.3.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)