### PR TITLE
[hari] sdk: ADK 0.6 object-param callbacks + delegation request DTO defaults

### DIFF
--- a/src/integrations/google_adk.ts
+++ b/src/integrations/google_adk.ts
@@ -340,9 +340,24 @@ export class ArmorIQADKBundle {
       afterToolCallback: agent.afterToolCallback,
     };
     agent.afterModelCallback = (...args: any[]) => this.afterModel(args[0], args[1]);
-    agent.beforeToolCallback = (tool: any, args: any, ctx?: any) => this.beforeTool(tool, args, ctx);
-    agent.afterToolCallback = (tool: any, args: any, ctx?: any, response?: any) =>
-      this.afterTool(tool, args, ctx, response);
+    agent.beforeToolCallback = (...args: any[]) => {
+      const a = args[0];
+      // Require `tool` specifically — anything else means we're in legacy
+      // positional mode and a is the BaseTool itself.
+      if (a && typeof a === 'object' && 'tool' in a) {
+        return this.beforeTool(a.tool, a.args, a.context ?? a.toolContext);
+      }
+      return this.beforeTool(a, args[1], args[2]);
+    };
+    agent.afterToolCallback = (...args: any[]) => {
+      const a = args[0];
+      // Require `tool` specifically — anything else means we're in legacy
+      // positional mode and a is the BaseTool itself.
+      if (a && typeof a === 'object' && 'tool' in a) {
+        return this.afterTool(a.tool, a.args, a.context ?? a.toolContext, a.response);
+      }
+      return this.afterTool(a, args[1], args[2], args[3]);
+    };
     return this;
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -490,10 +490,17 @@ export class ArmorIQSession {
     const email = userEmail ?? internals.userId ?? 'unknown@armoriq';
     const { mcp, action } = this.toolNameParser(toolName);
     const resolvedMcp = this.mcpByAction.get(action) ?? mcp;
-    const amount = ArmorIQSession.extractAmount(toolArgs) ?? 0;
+    const rawAmount = ArmorIQSession.extractAmount(toolArgs) ?? 0;
+    // Single normalized amount used for BOTH the approved-delegation lookup and
+    // the create call — must agree, otherwise the SDK keeps creating new pending
+    // rows because the existing approved one (created at safeAmount) won't match
+    // a check sent at rawAmount. Backend doesn't filter by amount today (see
+    // conmap-auto delegation.service.ts checkApprovedDelegation), but staying
+    // consistent here is forward-compatible.
+    const safeAmount = typeof rawAmount === 'number' && rawAmount >= 0.01 ? rawAmount : 0.01;
 
     try {
-      const approved = await this.client.checkApprovedDelegation(email, action, amount);
+      const approved = await this.client.checkApprovedDelegation(email, action, safeAmount);
       if (approved) {
         try {
           if (approved.delegationId) {
@@ -516,12 +523,20 @@ export class ArmorIQSession {
 
     let delegationId: string | undefined;
     try {
+      // The conmap-auto DTO requires amount/requesterRole/requesterLimit; for
+      // non-financial holds (PHI write, prior-auth, etc.) the SDK supplies
+      // healthcare-shaped defaults so the row gets created. The approver UI
+      // can read the original tool args from `arguments`. requesterRole
+      // matches the default used elsewhere in the SDK (resolveUserRole
+      // fallback in client.ts).
       const result = await this.client.createDelegationRequest({
         tool: action,
         action,
         arguments: toolArgs,
-        amount: amount || undefined,
+        amount: safeAmount,
         requesterEmail: email,
+        requesterRole: 'agent_user',
+        requesterLimit: 0,
         domain: resolvedMcp,
         planId: this.currentToken?.planId,
         intentReference: this.currentToken?.tokenId,


### PR DESCRIPTION
## Summary

Two related fixes uncovered while running the iHealth agent end-to-end against the merged feat/armorhealth stack across conmap-auto, proxy, frontend, opa and ihealth_agent. Without these, the prior-auth delegation flow looks like it's working server-side but no pending row gets created and the agent silently falls open.

### 1. ADK >=0.6 object-param callbacks
`@google/adk` >=0.6 passes lifecycle callbacks a single object argument (`{ tool, args, context }` / `{ context, response }`). The SDK's `install()` was wiring `beforeToolCallback` / `afterToolCallback` with positional parameters, so `tool?.name` resolved to `undefined` and the SDK fell open with `enforceSdk("[object Object]") called before startPlan()`.

`install()` now detects the new object form and unwraps it, while still supporting the legacy positional signature for older ADK versions.

`afterModelCallback` install is left vanilla on purpose: ihealth_agent PR #3 prototype-patches `ArmorIQADKBundle.prototype.afterModel` directly with the new shape (dynamic plan capture). Splitting the object on the install side would break that patch.

### 2. Healthcare delegation request DTO defaults
`conmap-auto`'s `CreateDelegationRequestDto` requires:
- `amount: number` (>=0.01, <=10M)
- `requesterRole: string` (non-empty)
- `requesterLimit: number` (>=0)

`handleHold()` was sending `amount: undefined` and not sending `requesterRole` / `requesterLimit` at all, so `POST /delegation/request` rejected every call with `400 Bad Request`. The HOLD response still came back to the SDK caller, but no pending `delegation_requests` row was ever inserted — approvers had nothing to approve and the SDK polled forever.

Added healthcare-friendly defaults: `amount: 0.01` placeholder when no monetary value is in tool args, `requesterRole: 'agent'`, `requesterLimit: 0`. Original tool args remain in `arguments` so approver UI can show real context.

## Test plan
- [x] Run iHealth agent (`npm start` in `ihealth_agent/backend`) against local conmap-auto + proxy + iap stack
- [x] Send `find 3 patients with family name Smith` — expect ALLOW (`tool_success`)
- [x] Send `delete the patient with id ailovdisyb2` — expect BLOCK (`enforcement {action:block, reason:tool_not_in_allowlist}`)
- [x] Send `create a Procedure for patient ... procedure code 70553` against a policy with `priorAuthorization.requiredProcedureCodes: [70553]` — expect HOLD; `delegation_requests` row appears with `status=pending`, `reason=prior_auth_required`
- [x] Approve via Delegation Approvals UI — agent's tool card flips to success on next poll
- [x] Reject via UI — agent shows REJECTED / "Approval timed out"

Pairs with `armoriq/conmap-auto#195` (which adds `priorAuthorization` enforcement and is patched to extract FHIR-nested codes via [d110c0a](https://github.com/armoriq/conmap-auto/commit/d110c0a)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)