### PR TITLE
fix: use userEmailOverride for userId in token and enforce

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -248,7 +248,12 @@ export class ArmorIQClient {
       defaultProxyEndpoint: this.defaultProxyEndpoint,
       httpClient: this.httpClient,
       userId: this.userId,
+      agentId: this.agentId,
     };
+  }
+
+  _setAgentId(agentId: string) {
+    this.agentId = agentId;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -247,7 +247,7 @@ export class ArmorIQClient {
       backendEndpoint: this.backendEndpoint,
       defaultProxyEndpoint: this.defaultProxyEndpoint,
       httpClient: this.httpClient,
-      userId: this.userId,
+      userId: this.userEmailOverride || this.userId,
       agentId: this.agentId,
     };
   }
@@ -586,7 +586,7 @@ export class ArmorIQClient {
     );
 
     const payload = {
-      user_id: this.userId,
+      user_id: this.userEmailOverride || this.userId,
       agent_id: this.agentId,
       context_id: this.contextId,
       plan: planCapture.plan,
@@ -714,7 +714,7 @@ export class ArmorIQClient {
       iamContext.user_email = userEmail;
     }
     if (intentToken.rawToken) {
-      iamContext.user_id = intentToken.rawToken.user_id || this.userId;
+      iamContext.user_id = intentToken.rawToken.user_id || this.userEmailOverride || this.userId;
       iamContext.agent_id = intentToken.rawToken.agent_id || this.agentId;
     }
 

--- a/src/integrations/google_adk.ts
+++ b/src/integrations/google_adk.ts
@@ -49,6 +49,7 @@ export interface ArmorIQADKOptions {
   validitySeconds?: number;
   mode?: SessionMode;
   llm?: string;
+  agentName?: string;
 }
 
 /**
@@ -81,7 +82,7 @@ export class ArmorIQADK {
       proxyEndpoint: opts.proxyEndpoint ?? opts.backendEndpoint,
       useProduction: opts.useProduction ?? true,
       userId: 'agent',
-      agentId: 'agent',
+      agentId: opts.agentName || 'agent',
     });
     this.defaultMcpName = opts.defaultMcpName;
     this.customParser = opts.toolNameParser;
@@ -94,12 +95,16 @@ export class ArmorIQADK {
     if (!this.bootstrapData) {
       this.bootstrapData = await this.client.bootstrap();
       const orgName = this.bootstrapData.org?.name ?? 'unknown';
+      const agentName = this.bootstrapData.agent?.name;
+      if (agentName) {
+        this.client._setAgentId(agentName);
+      }
       const mcps = Array.isArray(this.bootstrapData.mcps)
         ? this.bootstrapData.mcps.map((m: any) => m.name)
         : [];
       const toolMapSize = Object.keys(this.bootstrapData.toolMap ?? {}).length;
       console.info(
-        `[armoriq] bootstrap: org=${orgName} mcps=${JSON.stringify(mcps)} toolMap=${toolMapSize}`,
+        `[armoriq] bootstrap: org=${orgName} agent=${agentName ?? 'unknown'} mcps=${JSON.stringify(mcps)} toolMap=${toolMapSize}`,
       );
     }
     return this.bootstrapData!;

--- a/src/session.ts
+++ b/src/session.ts
@@ -276,6 +276,7 @@ export class ArmorIQSession {
           intent_token: this.currentToken.rawToken,
           policy_snapshot: this.currentToken.policySnapshot,
           user_email: userEmail,
+          agent_id: internals.agentId || undefined,
         },
         {
           headers: { 'X-API-Key': internals.apiKey, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- **`userEmailOverride` flows through all SDK paths** — `forUser()` sets `userEmailOverride`, which now correctly overrides the hardcoded `userId: 'agent'` in three places: `_sessionInternals()`, `requestIntentToken()`, and `invokeMCPAction()`. Previously, multi-user ADK agents always sent `userId: 'agent'`, making plans and delegations unattributable to actual users (Resolves #49)
- **Pass `agent_id` in SDK enforce request** — Enforce calls now include `agent_id` from bootstrap for cross-agent policy scoping

## Resolves

- #49 — ADK userId still hardcoded to `'agent'`

## Files Changed

- `src/client.ts` — Use `this.userEmailOverride || this.userId` in 3 locations (session internals, intent token, MCP invocation)
- `src/integrations/google_adk.ts` — ADK integration: pass agent_id in enforce
- `src/session.ts` — Session type update

## Test plan

- [x] Plan created with `userId: aniket@armoriq.io` instead of `userId: agent`
- [x] Delegation requests show correct requester email
- [x] Self-approval guard works (requires different user's email)
- [x] E2E: enforce → hold → delegation → approve flow with correct user attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)