### PR TITLE
fix: fail-hold on transient errors, add defaultUserEmail

### DIFF
--- a/src/integrations/google_adk.ts
+++ b/src/integrations/google_adk.ts
@@ -45,6 +45,7 @@ export interface ArmorIQADKOptions {
   proxyEndpoint?: string;
   useProduction?: boolean;
   defaultMcpName?: string;
+  defaultUserEmail?: string;
   toolNameParser?: ToolNameParser;
   validitySeconds?: number;
   mode?: SessionMode;
@@ -81,7 +82,7 @@ export class ArmorIQADK {
       iapEndpoint: opts.iapEndpoint ?? opts.backendEndpoint,
       proxyEndpoint: opts.proxyEndpoint ?? opts.backendEndpoint,
       useProduction: opts.useProduction ?? true,
-      userId: 'agent',
+      userId: opts.defaultUserEmail || 'agent',
       agentId: opts.agentName || 'agent',
     });
     this.defaultMcpName = opts.defaultMcpName;

--- a/src/session.ts
+++ b/src/session.ts
@@ -311,7 +311,14 @@ export class ArmorIQSession {
         matchedPolicy: matched,
       };
     } catch (e) {
-      console.warn(`enforceSdk() failed: ${(e as Error).message}. Allowing tool call.`);
+      const msg = (e as Error).message ?? '';
+      const isTransient =
+        /timeout|ECONNREFUSED|ECONNRESET|ETIMEDOUT|socket hang up|5\d\d/i.test(msg);
+      if (isTransient) {
+        console.warn(`enforceSdk() transient error: ${msg}. Keeping hold state.`);
+        return { allowed: false, action: 'hold', reason: `enforce-transient-error: ${msg}` };
+      }
+      console.warn(`enforceSdk() permanent error: ${msg}. Allowing tool call.`);
       return { allowed: true, action: 'allow', reason: 'enforce-unavailable' };
     }
   }
@@ -387,7 +394,14 @@ export class ArmorIQSession {
         matchedPolicy: policyName,
       };
     } catch (e) {
-      console.warn(`enforce() failed: ${(e as Error).message}. Allowing tool call.`);
+      const msg = (e as Error).message ?? '';
+      const isTransient =
+        /timeout|ECONNREFUSED|ECONNRESET|ETIMEDOUT|socket hang up|5\d\d/i.test(msg);
+      if (isTransient) {
+        console.warn(`enforce() transient error: ${msg}. Keeping hold state.`);
+        return { allowed: false, action: 'hold', reason: `enforce-transient-error: ${msg}` };
+      }
+      console.warn(`enforce() permanent error: ${msg}. Allowing tool call.`);
       return { allowed: true, action: 'allow', reason: 'enforce-unavailable' };
     }
   }


### PR DESCRIPTION
## Summary
- **enforceSdk() / enforce() fail-open → fail-hold**: Transient errors (timeout, ECONNREFUSED, 5xx) during the 30-min polling loop now return `{allowed: false, action: 'hold'}` instead of `{allowed: true}`. Only permanent/config errors still fail-open. This was the root cause of intermittent delegation bypass.
- **defaultUserEmail option**: Added to `ArmorIQADKOptions` so the client `userId` defaults to the user's email instead of `'agent'`, improving plan attribution in the dashboard.

## Test plan
- [x] 3/3 E2E hold → approve → agent respond cycles passed after this fix
- [x] Transient error regex tested: matches timeout, ECONNREFUSED, ECONNRESET, ETIMEDOUT, socket hang up, 5xx
- [x] Permanent errors still fail-open (e.g. invalid API key, malformed payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)