### PR TITLE
feat(cli): --product flag for product-aware device approval (0.3.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -117,12 +117,27 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-export async function cmdLogin(args: { backend?: string; org?: string }): Promise<number> {
+export async function cmdLogin(args: {
+  backend?: string;
+  org?: string;
+  product?: string;
+}): Promise<number> {
   const backend = (args.backend ?? process.env.ARMORIQ_BACKEND_URL ?? backendBase()).replace(
     /\/+$/,
     '',
   );
   const requestedOrg = (args.org ?? '').trim();
+
+  // Product is a soft hint for product-aware browser approval branding
+  // (e.g. "armorclaude", "armorcodex"). Falls back to ARMORIQ_PRODUCT so
+  // older shell scripts that set the env var instead of passing the flag
+  // still work. Canonicalized to lowercase + alphanum/-_ so admin-side
+  // attribution filters (which key off the lowercase slug) always match.
+  const rawProduct = (args.product ?? process.env.ARMORIQ_PRODUCT ?? '').trim();
+  const requestedProduct = rawProduct
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '')
+    .slice(0, 32);
 
   out('');
   out('  \x1b[1m\x1b[36m┃ ArmorIQ Login\x1b[0m');
@@ -132,9 +147,12 @@ export async function cmdLogin(args: { backend?: string; org?: string }): Promis
   const callbackUrl = `http://localhost:${port}/callback`;
   const { server, once: callbackOnce } = startCallbackServer(port);
 
+  const codeBody: Record<string, string> = { callback_url: callbackUrl };
+  if (requestedProduct) codeBody.product = requestedProduct;
+
   let dc: any;
   try {
-    const r = await axios.post(`${backend}/auth/device/code`, { callback_url: callbackUrl }, { timeout: 10000 });
+    const r = await axios.post(`${backend}/auth/device/code`, codeBody, { timeout: 10000 });
     dc = r.data;
   } catch (e) {
     server.close();
@@ -150,6 +168,11 @@ export async function cmdLogin(args: { backend?: string; org?: string }): Promis
   let browserUrl =
     `${verification_uri_complete}${sep}callback=${encodeURIComponent(callbackUrl)}`;
   if (requestedOrg) browserUrl += `&org=${encodeURIComponent(requestedOrg)}`;
+  // Backend already appends product to verification_uri_complete when the
+  // POST body carries it; but we also include it here client-side so an
+  // older backend that ignores the body still surfaces the product to the
+  // browser approval page.
+  if (requestedProduct) browserUrl += `&product=${encodeURIComponent(requestedProduct)}`;
 
   out('  Opening browser...\n');
   openBrowser(browserUrl);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,7 +18,11 @@ armoriq — ArmorIQ SDK CLI
 Usage: armoriq <command> [options]
 
 Commands:
-  login [--org <name>]       OAuth device-code login flow
+  login [--org <name>] [--product <slug>]
+                             OAuth device-code login flow.
+                             --product is a hint for product-aware branding
+                             (armorclaude, armorcodex). Also reads
+                             ARMORIQ_PRODUCT env var.
   logout                     Remove cached credentials
   whoami                     Show the currently logged-in account
 
@@ -65,7 +69,8 @@ async function run(argv: Argv): Promise<number> {
       const { cmdLogin } = await import('./commands/auth.js');
       const org = parseFlag(rest, 'org') as string | undefined;
       const backend = parseFlag(rest, 'backend') as string | undefined;
-      return cmdLogin({ org, backend });
+      const product = parseFlag(rest, 'product') as string | undefined;
+      return cmdLogin({ org, backend, product });
     }
     case 'logout': {
       const { cmdLogout } = await import('./commands/auth.js');


### PR DESCRIPTION
## Why

The npm CLI's \`login\` command didn't know about \`--product\`. The installer scripts (\`install_armorclaude.sh\`, \`install_armorcodex.sh\`) try to pass it on the npm path, and the CLI silently dropped it. Every device approval through the installer landed with \`product=NULL\` in the backend, so the admin dashboard's per-product analytics pages (\`/products/armor-claude\`, \`/products/armor-codex\`) saw zero attributed installs.

Mirrors the Python SDK changes from [armoriq/armoriq-sdk-customer#31](https://github.com/armoriq/armoriq-sdk-customer/pull/31) (already shipped as \`armoriq-sdk\` 0.3.6 on PyPI).

## What

In \`src/cli/commands/auth.ts\`:
- \`cmdLogin\` accepts \`product?: string\`
- Reads \`ARMORIQ_PRODUCT\` env var as a fallback so older shell scripts that set the env var instead of passing the flag still work
- Canonicalizes to lowercase + alphanum/-_ (max 32 chars) so the slug always matches the admin's exact-equality filters
- Adds \`product\` to the \`POST /auth/device/code\` body
- Also appends \`&product=\` to the browser verification URL client-side (backwards-compat for any backend that ignores the body)

In \`src/cli/index.ts\`:
- \`parseFlag\` for \`--product\` on the \`login\` subcommand
- Help text updated

Version bumped to 0.3.2 so the next \`npm publish\` ships the new behavior as \`@armoriq/sdk\` 0.3.2.

## After merge
1. Tag \`v0.3.2\` on \`main\`
2. \`npm publish\` (or trigger the existing publish workflow) → \`@armoriq/sdk\` 0.3.2 lands on npm
3. The installer-side PRs (one for each of armorClaude / armorCodex) can then point at the new prod version and \`--product\` flows through end-to-end

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [x] \`node dist/cli/index.js help\` shows \`--product\` in the login section
- [ ] After publish: \`npx @armoriq/sdk@0.3.2 login --product armorcodex\` posts \`product\` in the device-code body and appends \`&product=armorcodex\` to the verification URL
- [ ] After staging deploy: device approval lands an api-key row with \`product='armorcodex'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)