### PR TITLE
feat(session): true-reanchor default + remove ARMORIQ_TRUE_REANCHOR env

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -256,10 +256,6 @@ export class ArmorIQClient {
     this.agentId = agentId;
   }
 
-  getAgentId(): string {
-    return this.agentId;
-  }
-
   /**
    * Start a session bound to this client. Mirrors PY ArmorIQClient.start_session.
    */
@@ -813,6 +809,28 @@ export class ArmorIQClient {
     const valueDigest = crypto.createHash('sha256').update(valueStr, 'utf8').digest('hex');
     headers['X-CSRG-Value-Digest'] = valueDigest;
 
+    // Subtree delegation envelope (Bug 4 wiring): when this token was minted
+    // by client.delegateSubtree(), attach the inclusion proof + subtree root
+    // so the proxy's PEP can verify the child's authority chains to the
+    // parent plan root and reject calls outside the subtree.
+    const subtree = (intentToken as any).subtreeDelegation;
+    if (subtree && typeof subtree === 'object') {
+      if (typeof subtree.subtreePath === 'string') {
+        headers['X-CSRG-Subtree-Path'] = subtree.subtreePath;
+      }
+      if (typeof subtree.subtreeRoot === 'string' && subtree.subtreeRoot.length > 0) {
+        headers['X-CSRG-Subtree-Root'] = subtree.subtreeRoot;
+      }
+      if (typeof subtree.parentPlanHash === 'string' && subtree.parentPlanHash.length > 0) {
+        headers['X-CSRG-Parent-Root'] = subtree.parentPlanHash;
+      }
+      if (Array.isArray(subtree.inclusionProof) && subtree.inclusionProof.length > 0) {
+        // Base64-encode to keep the header reasonable when proof is long.
+        const proofJson = JSON.stringify(subtree.inclusionProof);
+        headers['X-CSRG-Subtree-Proof'] = Buffer.from(proofJson, 'utf8').toString('base64');
+      }
+    }
+
     // Call proxy
     try {
       const startTime = Date.now();
@@ -1026,6 +1044,167 @@ export class ArmorIQClient {
         targetAgent,
         undefined,
         statusCode
+      );
+    }
+  }
+
+  // -------------------- Trust Update primitive --------------------
+  // Three thin client methods that talk to conmap-auto's /iap/trust/* API.
+  // Devs should treat them as one-liners — no Merkle awareness needed.
+
+  /**
+   * Revoke an issued intent token. Returns once the IAP backend has signed
+   * the revocation delta and broadcast it on the trust channel; the proxy
+   * fleet refuses the token within Δ (paper target ~55 ms in single region).
+   */
+  async revoke(
+    intentToken: IntentToken,
+    reason: string,
+    opts?: { cascade?: boolean; planId?: string; intentReference?: string }
+  ): Promise<{ trustId: string; delta: any; cascadedRevocations?: string[] }> {
+    let token = intentToken.rawToken;
+    if (typeof token === 'object' && token && 'token' in token) token = token.token;
+    const body = {
+      token,
+      reason,
+      cascade: opts?.cascade ?? true,
+      planId: opts?.planId ?? intentToken.planId,
+      intentReference: opts?.intentReference,
+    };
+    const url = `${this.backendEndpoint}/iap/trust/revoke`;
+    try {
+      const response = await this._retryPost(url, body, { timeout: 10000 });
+      if (response.status >= 400) {
+        throw new Error(`HTTP ${response.status}: ${JSON.stringify(response.data)}`);
+      }
+      return response.data;
+    } catch (error: any) {
+      throw new DelegationException(
+        `Revoke failed: ${error.response?.data || error.message}`,
+        undefined,
+        intentToken.tokenId,
+        error.response?.status
+      );
+    }
+  }
+
+  /**
+   * Re-anchor a plan that has changed mid-execution. The IAP backend signs a
+   * delta tying the previous plan hash to the new one; subsequent tool calls
+   * carry the new merkle_root and authorize against it.
+   */
+  async reanchor(
+    intentToken: IntentToken,
+    updatedPlan: Record<string, any>,
+    reason?: string,
+    opts?: { planId?: string; intentReference?: string }
+  ): Promise<{ trustId: string; delta: any }> {
+    const body = {
+      newPlan: updatedPlan,
+      reason,
+      planId: opts?.planId ?? intentToken.planId,
+      intentReference: opts?.intentReference,
+    };
+    const url = `${this.backendEndpoint}/iap/trust/reanchor`;
+    try {
+      const response = await this._retryPost(url, body, { timeout: 10000 });
+      if (response.status >= 400) {
+        throw new Error(`HTTP ${response.status}: ${JSON.stringify(response.data)}`);
+      }
+      return response.data;
+    } catch (error: any) {
+      throw new DelegationException(
+        `Reanchor failed: ${error.response?.data || error.message}`,
+        undefined,
+        intentToken.tokenId,
+        error.response?.status
+      );
+    }
+  }
+
+  /**
+   * Issue a subtree-bounded child token. Unlike the legacy `delegate()` which
+   * forwards to the older approval-style endpoint, this returns a token plus a
+   * Merkle inclusion proof linking the subtree root to the parent plan root.
+   * The child agent presents the proof on every tool call; the proxy verifies
+   * scope confinement before allowing execution.
+   */
+  async delegateSubtree(
+    intentToken: IntentToken,
+    opts: {
+      delegatePublicKey: string;
+      subtreePath: string;
+      validitySeconds?: number;
+      parentPlan?: Record<string, any>;
+      allowedTools?: string[];
+      targetAgent?: string;
+      planId?: string;
+      intentReference?: string;
+    }
+  ): Promise<{
+    trustId: string;
+    delta: any;
+    inclusionProof: any[];
+    subtreeRoot: string;
+    /**
+     * Drop-in IntentToken the sub-agent passes to its own client.invoke().
+     * Carries the subtreeDelegation envelope so the SDK auto-attaches the
+     * X-CSRG-Subtree-* headers and the proxy enforces scope confinement.
+     */
+    delegatedToken: IntentToken;
+  }> {
+    let parentToken = intentToken.rawToken;
+    if (typeof parentToken === 'object' && parentToken && 'token' in parentToken) {
+      parentToken = parentToken.token;
+    }
+    const body = {
+      parentToken,
+      delegatePublicKey: opts.delegatePublicKey,
+      validitySeconds: opts.validitySeconds ?? 3600,
+      parentPlan: opts.parentPlan,
+      subtreePath: opts.subtreePath,
+      planId: opts.planId ?? intentToken.planId,
+      intentReference: opts.intentReference,
+    };
+    const url = `${this.backendEndpoint}/iap/trust/delegate`;
+    try {
+      const response = await this._retryPost(url, body, { timeout: 10000 });
+      if (response.status >= 400) {
+        throw new Error(`HTTP ${response.status}: ${JSON.stringify(response.data)}`);
+      }
+      const data = response.data;
+      const payload = data?.delta?.payload ?? {};
+      const inclusionProof = payload.inclusion_proof ?? [];
+      const subtreeRoot = payload.subtree_node_hash ?? '';
+      const parentPlanHash = payload.parent_plan_hash ?? intentToken.planHash;
+
+      // The delegated token is the parent token *plus* a subtreeDelegation
+      // envelope. The SDK's invoke() reads this envelope and attaches the
+      // X-CSRG-Subtree-* headers for proxy-side proof verification (Bug 4).
+      const delegatedToken: IntentToken = {
+        ...intentToken,
+        subtreeDelegation: {
+          subtreePath: opts.subtreePath,
+          subtreeRoot,
+          parentPlanHash,
+          inclusionProof,
+          parentTokenId: intentToken.tokenId,
+        },
+      };
+
+      return {
+        trustId: data.trustId,
+        delta: data.delta,
+        inclusionProof,
+        subtreeRoot,
+        delegatedToken,
+      };
+    } catch (error: any) {
+      throw new DelegationException(
+        `delegateSubtree failed: ${error.response?.data || error.message}`,
+        opts.targetAgent,
+        undefined,
+        error.response?.status
       );
     }
   }

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -122,6 +122,24 @@ export class DelegationException extends ArmorIQException {
 }
 
 /**
+ * Raised when an intent token has been revoked by the IAP backend and the
+ * proxy refused to execute the action. The proxy returns 401 with header
+ * X-Armoriq-Revoked: true. Catch this to refresh the token and retry.
+ */
+export class RevokedTokenError extends ArmorIQException {
+  public tokenId?: string;
+  public reason?: string;
+
+  constructor(message: string, tokenId?: string, reason?: string) {
+    super(message);
+    this.name = 'RevokedTokenError';
+    this.tokenId = tokenId;
+    this.reason = reason;
+    Object.setPrototypeOf(this, RevokedTokenError.prototype);
+  }
+}
+
+/**
  * Raised when a policy enforcement blocks the action.
  */
 export class PolicyBlockedException extends ArmorIQException {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
   MCPInvocationException,
   TokenExpiredException,
   DelegationException,
+  RevokedTokenError,
   ConfigurationException,
   PolicyBlockedException,
   PolicyHoldException,

--- a/src/integrations/google_adk.ts
+++ b/src/integrations/google_adk.ts
@@ -84,8 +84,10 @@ export class ArmorIQADK {
   public readonly trueReanchor: boolean;
   private customParser?: ToolNameParser;
   private bootstrapData?: Record<string, any>;
+  private readonly explicitAgentName?: string;
 
   constructor(opts: ArmorIQADKOptions) {
+    this.explicitAgentName = opts.agentName;
     this.client = new ArmorIQClient({
       apiKey: opts.apiKey,
       backendEndpoint: opts.backendEndpoint,
@@ -93,7 +95,9 @@ export class ArmorIQADK {
       proxyEndpoint: opts.proxyEndpoint ?? opts.backendEndpoint,
       useProduction: opts.useProduction ?? true,
       userId: 'agent',
-      agentId: opts.agentName || 'agent',
+      // When agentName is not explicitly provided, omit agentId so the
+      // client constructor's env fallback (AGENT_ID) can kick in.
+      ...(opts.agentName ? { agentId: opts.agentName } : {}),
     });
     this.defaultMcpName = opts.defaultMcpName;
     this.customParser = opts.toolNameParser;
@@ -107,16 +111,30 @@ export class ArmorIQADK {
     if (!this.bootstrapData) {
       this.bootstrapData = await this.client.bootstrap();
       const orgName = this.bootstrapData.org?.name ?? 'unknown';
-      const agentName = this.bootstrapData.agent?.name;
-      if (agentName) {
-        this.client._setAgentId(agentName);
+
+      // Auto-resolve agentId from bootstrap only when the caller didn't
+      // pass an explicit agentName. The agents[] list (new in bootstrap
+      // response) is authoritative — the legacy agent.name returned the
+      // API key's display name which caused cross-agent policy
+      // attribution issues (#199).
+      let resolvedAgentName: string | undefined;
+      if (!this.explicitAgentName) {
+        const agents: Array<{ agentId: string; name: string }> = this.bootstrapData.agents ?? [];
+        const single = agents.length === 1 ? agents[0] : null;
+        const fallback = this.bootstrapData.agent?.name;
+        resolvedAgentName = single?.name ?? fallback;
+        if (resolvedAgentName) {
+          this.client._setAgentId(resolvedAgentName);
+        }
       }
+
       const mcps = Array.isArray(this.bootstrapData.mcps)
         ? this.bootstrapData.mcps.map((m: any) => m.name)
         : [];
       const toolMapSize = Object.keys(this.bootstrapData.toolMap ?? {}).length;
+      const loggedAgentName = this.explicitAgentName ?? resolvedAgentName ?? 'unknown';
       console.info(
-        `[armoriq] bootstrap: org=${orgName} agent=${agentName ?? 'unknown'} mcps=${JSON.stringify(mcps)} toolMap=${toolMapSize}`,
+        `[armoriq] bootstrap: org=${orgName} agent=${loggedAgentName} mcps=${JSON.stringify(mcps)} toolMap=${toolMapSize}`,
       );
     }
     return this.bootstrapData!;

--- a/src/integrations/google_adk.ts
+++ b/src/integrations/google_adk.ts
@@ -50,6 +50,12 @@ export interface ArmorIQADKOptions {
   mode?: SessionMode;
   llm?: string;
   agentName?: string;
+  /**
+   * Phase 4 C5c — TRUE reanchor mode. When true, plan growth records a
+   * delta and SKIPS the re-mint (single JWT continues across chain).
+   * Requires C5a + C5b backend infrastructure. See SessionOptions.
+   */
+  trueReanchor?: boolean;
 }
 
 /**
@@ -71,13 +77,15 @@ export class ArmorIQADK {
   public readonly llm: string;
   public readonly validitySeconds: number;
   public readonly defaultMcpName?: string;
+  // autoReanchor flag removed 2026-05-13 — always on. Property retained
+  // as `readonly = true` so any caller reading factory.autoReanchor still
+  // observes the same value, but no env or option toggles it.
+  public readonly autoReanchor = true;
+  public readonly trueReanchor: boolean;
   private customParser?: ToolNameParser;
   private bootstrapData?: Record<string, any>;
-  private explicitAgentName: boolean;
 
   constructor(opts: ArmorIQADKOptions) {
-    const agentName = opts.agentName || process.env.AGENT_ID || '';
-    this.explicitAgentName = !!agentName;
     this.client = new ArmorIQClient({
       apiKey: opts.apiKey,
       backendEndpoint: opts.backendEndpoint,
@@ -85,41 +93,30 @@ export class ArmorIQADK {
       proxyEndpoint: opts.proxyEndpoint ?? opts.backendEndpoint,
       useProduction: opts.useProduction ?? true,
       userId: 'agent',
-      agentId: agentName || 'agent',
+      agentId: opts.agentName || 'agent',
     });
     this.defaultMcpName = opts.defaultMcpName;
     this.customParser = opts.toolNameParser;
     this.validitySeconds = opts.validitySeconds ?? 300;
     this.mode = opts.mode ?? 'sdk';
     this.llm = opts.llm ?? 'agent';
+    this.trueReanchor = opts.trueReanchor ?? true;
   }
 
   async bootstrap(): Promise<Record<string, any>> {
     if (!this.bootstrapData) {
       this.bootstrapData = await this.client.bootstrap();
       const orgName = this.bootstrapData.org?.name ?? 'unknown';
-
-      // Auto-resolve agentId from bootstrap only when not explicitly provided.
-      // The agents list (new in bootstrap response) is authoritative — the
-      // legacy agent.name field returned the API key's display name which
-      // caused cross-agent policy attribution (#199).
-      if (!this.explicitAgentName) {
-        const agents: Array<{ agentId: string; name: string }> = this.bootstrapData.agents ?? [];
-        const single = agents.length === 1 ? agents[0] : null;
-        const fallback = this.bootstrapData.agent?.name;
-        const resolved = single?.name ?? fallback;
-        if (resolved) {
-          this.client._setAgentId(resolved);
-        }
+      const agentName = this.bootstrapData.agent?.name;
+      if (agentName) {
+        this.client._setAgentId(agentName);
       }
-
-      const resolvedAgent = this.client.getAgentId?.() ?? 'unknown';
       const mcps = Array.isArray(this.bootstrapData.mcps)
         ? this.bootstrapData.mcps.map((m: any) => m.name)
         : [];
       const toolMapSize = Object.keys(this.bootstrapData.toolMap ?? {}).length;
       console.info(
-        `[armoriq] bootstrap: org=${orgName} agent=${resolvedAgent} mcps=${JSON.stringify(mcps)} toolMap=${toolMapSize}`,
+        `[armoriq] bootstrap: org=${orgName} agent=${agentName ?? 'unknown'} mcps=${JSON.stringify(mcps)} toolMap=${toolMapSize}`,
       );
     }
     return this.bootstrapData!;
@@ -203,6 +200,7 @@ export class ArmorIQADKBundle {
         llm: this.factory.llm,
         toolNameParser: this.parser,
         defaultMcpName: this.factory.defaultMcpName,
+        trueReanchor: this.factory.trueReanchor,
       };
       this.session = this.scope.startSession(opts);
     }

--- a/src/models.ts
+++ b/src/models.ts
@@ -36,6 +36,29 @@ export interface IntentToken {
   jwtToken?: string;
   /** OPA-formatted policy snapshot for proxy → OPA direct enforcement */
   policySnapshot?: Array<Record<string, any>>;
+
+  /**
+   * Subtree-bounded delegation envelope. Present iff this token was minted
+   * by `client.delegateSubtree(...)`. Carries the Merkle inclusion proof
+   * that lets the proxy verify the child's authority chains to the parent
+   * plan root, confining the child's allowed actions to `subtreePath`.
+   *
+   * When this is set, the SDK's `invoke()` automatically attaches three
+   * extra headers on every tool call:
+   *   - X-CSRG-Subtree-Path     = subtreePath
+   *   - X-CSRG-Subtree-Root     = subtreeRoot (h_subtree)
+   *   - X-CSRG-Subtree-Proof    = base64(JSON.stringify(inclusionProof))
+   *   - X-CSRG-Parent-Root      = parentPlanHash (h_P)
+   * The proxy's PEP verifies the proof and rejects calls whose CSRG path
+   * falls outside the subtreePath boundary.
+   */
+  subtreeDelegation?: {
+    subtreePath: string;
+    subtreeRoot: string;
+    parentPlanHash: string;
+    inclusionProof: Array<Record<string, any>>;
+    parentTokenId?: string;
+  };
 }
 
 /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -31,6 +31,45 @@ export interface SessionOptions {
   validitySeconds?: number;
   llm?: string;
   mode?: SessionMode;
+  /**
+   * Phase 4 C5c — TRUE reanchor mode.
+   *
+   * When true, plan growth records a ReAnchor delta and SKIPS the re-mint
+   * entirely. The same JWT continues; the proxy walks the signed delta
+   * chain to verify continuity. This is what the IAP paper §"Trust Update
+   * Primitive" actually specifies: one HTTP call per growth, one JWT
+   * spanning the chain, audit lineage at zero net cost.
+   *
+   * Requires:
+   *   - csrg-iap with C5a chain-aware verify_action (delta_chain support)
+   *   - armoriq-proxy-server with C5b DeltaChainCacheService
+   *   - conmap-auto with GET /iap/trust/chain endpoint
+   *
+   * If any of those are missing, set trueReanchor=false and rely on the
+   * pragmatic v2 (record delta + remint) which works on older infra.
+   *
+   * Default true as of 2026-05-17 post-soak (C5 chain validation fully shipped
+   * across SDK / proxy / csrg-iap / conmap-auto). ARMORIQ_TRUE_REANCHOR env
+   * fallback removed — pass `trueReanchor: false` explicitly to opt out.
+   */
+  trueReanchor?: boolean;
+  /**
+   * Phase 4 A6 — reanchor granularity.
+   *
+   *  - 'eager'    (default): every plan growth fires a reanchor immediately.
+   *               Required when mid-turn tool calls run against newly
+   *               declared steps (the typical ADK loop pattern).
+   *  - 'deferred': accumulate plan growths in memory; fire ONE reanchor
+   *               at flushReanchor() (called from Stop hook or explicitly
+   *               by the consumer). Saves N-1 calls per turn for multi-
+   *               growth turns. Safe when the LLM declares the plan up
+   *               front and only mid-turn growths are *additions* of tools
+   *               that won't fire until next turn (typical Claude Code).
+   *
+   * Default 'eager'. Reads ARMORIQ_REANCHOR_GRANULARITY env var if option
+   * unset.
+   */
+  reanchorGranularity?: 'eager' | 'deferred';
 }
 
 export interface EnforceResult {
@@ -60,6 +99,15 @@ export class ArmorIQSession {
   private validitySeconds: number;
   private llm: string;
   private mode: SessionMode;
+  // autoReanchor flag removed 2026-05-13 — auto-reanchor is always-on now
+  // that the intermediate signing key (Change 1) makes signing sub-ms.
+  private readonly autoReanchor = true;
+  private trueReanchor: boolean;
+  private reanchorGranularity: 'eager' | 'deferred';
+  // Phase 4 A6: when granularity='deferred', hold the latest plan here and
+  // flush at flushReanchor() time. We coalesce N successive growths into
+  // one reanchor by always overwriting with the latest plan.
+  private pendingReanchorPlan?: any;
   private stepIndex = 0;
   private currentPlanHash?: string;
   private currentToken?: IntentToken;
@@ -74,6 +122,11 @@ export class ArmorIQSession {
     this.validitySeconds = o.validitySeconds ?? 3600;
     this.llm = o.llm ?? 'agent';
     this.mode = o.mode ?? 'local';
+    this.trueReanchor = o.trueReanchor ?? true;
+    const granEnv =
+      (typeof process !== 'undefined' && process.env?.ARMORIQ_REANCHOR_GRANULARITY) || '';
+    this.reanchorGranularity =
+      o.reanchorGranularity ?? (granEnv === 'deferred' ? 'deferred' : 'eager');
   }
 
   // ─── Plan capture ──────────────────────────────────────────────
@@ -106,6 +159,75 @@ export class ArmorIQSession {
     }
 
     const planCapture = this.client.capturePlan(this.llm, goal ?? this.llm, plan);
+
+    // Phase 4 A6 — deferred granularity: stash the latest plan, do not call
+    // reanchor yet. The next flushReanchor() (typically at Stop hook in
+    // armorClaude or at session.report end-of-turn for ADK) coalesces all
+    // accumulated growths into one delta. Saves N-1 calls per turn.
+    const wantsReanchor =
+      (this.trueReanchor || this.autoReanchor) && this.currentToken;
+    const deferred = this.reanchorGranularity === 'deferred';
+
+    if (wantsReanchor && deferred) {
+      // Always overwrite — coalescing collapses successive plans to the
+      // latest. The chain still records each ReAnchor at flush time as
+      // delta(prev_anchor → final_plan), which is what auditors care
+      // about (state-at-end-of-turn, not every intermediate proposal).
+      this.pendingReanchorPlan = plan;
+      // For trueReanchor in deferred mode: still skip the re-mint —
+      // continuation is the whole point. Update plan hash now so subsequent
+      // enforceLocal sees the new plan.
+      if (this.trueReanchor) {
+        this.currentPlanHash = h;
+        this.stepIndex = 0;
+        return this.currentToken!;
+      }
+      // For autoReanchor (pragmatic v2) in deferred mode: still need to
+      // re-mint because step_proofs are baked at issuance. Skip the
+      // delta call here; flushReanchor() catches up later.
+      const tokenA = await this.client.getIntentToken(planCapture, undefined, this.validitySeconds);
+      this.currentPlanHash = h;
+      this.currentToken = tokenA;
+      this.stepIndex = 0;
+      return tokenA;
+    }
+
+    // Phase 4 C5c — TRUE reanchor (eager): skip re-mint entirely.
+    // When trueReanchor is on AND we already have a token, just record the
+    // delta and continue with the same JWT. The proxy will walk the signed
+    // chain to verify continuity. One HTTP call instead of two; JWT identity
+    // preserved across the chain (paper's actual C3).
+    if (this.trueReanchor && this.currentToken) {
+      try {
+        await this.client.reanchor(this.currentToken, plan as any, 'plan grew (true-reanchor)');
+        // Update local state without re-minting. The JWT stays the same;
+        // only currentPlanHash advances so subsequent enforceLocal /
+        // dispatch calls see the new plan.
+        this.currentPlanHash = h;
+        this.stepIndex = 0;
+        return this.currentToken;
+      } catch (err) {
+        // If the delta record itself failed (network, signing error), fall
+        // through to the legacy re-mint path so the agent isn't stranded.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[armoriq] true-reanchor failed; falling back to re-mint: ${msg}`);
+      }
+    }
+
+    // Auto-reanchor (pragmatic v2): when the plan evolves mid-session and
+    // the flag is on, record a Trust Update ReAnchor delta so the audit log
+    // preserves the lineage between successive plan hashes. We re-mint the
+    // working token afterwards because (without C5c trueReanchor) the proxy
+    // pins to the JWT's plan_hash and step_proofs are baked at issuance.
+    if (this.autoReanchor && this.currentToken) {
+      try {
+        await this.client.reanchor(this.currentToken, plan as any, 'plan grew mid-session');
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[armoriq] auto-reanchor delta failed (continuing): ${msg}`);
+      }
+    }
+
     const token = await this.client.getIntentToken(planCapture, undefined, this.validitySeconds);
     this.currentPlanHash = h;
     this.currentToken = token;
@@ -607,6 +729,52 @@ export class ArmorIQSession {
     this.mcpByAction.clear();
     this.declaredTools.clear();
     this.stepIndex = 0;
+    this.pendingReanchorPlan = undefined;
+  }
+
+  /**
+   * Phase 4 A6 — flush any pending coalesced reanchor.
+   *
+   * Call this at the request boundary (Stop hook in armorClaude, end of
+   * turn in ADK consumers). If reanchorGranularity='deferred' and a plan
+   * growth was observed, this fires ONE reanchor delta covering the
+   * cumulative change from the prior anchor to the latest plan.
+   *
+   * Returns:
+   *   - { fired: true, trustId } when a delta was recorded
+   *   - { fired: false } when there was nothing pending or auto/true
+   *     reanchor is off
+   */
+  async flushReanchor(): Promise<{ fired: boolean; trustId?: string }> {
+    if (!this.pendingReanchorPlan) {
+      return { fired: false };
+    }
+    if (!this.currentToken) {
+      this.pendingReanchorPlan = undefined;
+      return { fired: false };
+    }
+    if (!this.trueReanchor && !this.autoReanchor) {
+      this.pendingReanchorPlan = undefined;
+      return { fired: false };
+    }
+
+    const planToFlush = this.pendingReanchorPlan;
+    // Optimistically clear so a retry in the caller doesn't double-fire.
+    this.pendingReanchorPlan = undefined;
+    try {
+      const result = await this.client.reanchor(
+        this.currentToken,
+        planToFlush as any,
+        'flush at request boundary',
+      );
+      return { fired: true, trustId: (result as any)?.trustId };
+    } catch (err) {
+      // Best-effort: log and stay silent so a flaky IAP doesn't gate
+      // session lifecycle.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[armoriq] flushReanchor failed: ${msg}`);
+      return { fired: false };
+    }
   }
 
   get currentTokenValue(): IntentToken | undefined {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -178,3 +178,220 @@ describe('ArmorIQSession.reset', () => {
     expect((s as any).declaredTools.size).toBe(0);
   });
 });
+
+describe('ArmorIQSession.startPlan auto-reanchor', () => {
+  // autoReanchor flag removed 2026-05-13 — auto-reanchor is always on.
+  // trueReanchor default flipped to true on 2026-05-17 post-soak; the legacy
+  // v2 path (record delta + re-mint) still ships for callers that opt out via
+  // trueReanchor: false, which is what these tests exercise.
+  it('always records a Trust Update ReAnchor delta on plan growth', async () => {
+    const client = makeClient();
+    const s = new ArmorIQSession(client, { trueReanchor: false, defaultMcpName: 'TestMcp' });
+
+    const reanchorMock = jest.fn().mockResolvedValue({ trustId: 'tr_abc', delta: {} });
+    const issueMock = jest
+      .fn()
+      .mockResolvedValueOnce(tokenWithPolicy())
+      .mockResolvedValueOnce(tokenWithPolicy());
+    (client as any).reanchor = reanchorMock;
+    (client as any).getIntentToken = issueMock;
+    (client as any).capturePlan = (_llm: string, _goal: string, plan: any) => plan;
+
+    await s.startPlan([{ name: 'echo', args: { text: 'hi' } }], 'goal');
+    expect(reanchorMock).not.toHaveBeenCalled();
+    expect(issueMock).toHaveBeenCalledTimes(1);
+
+    await s.startPlan(
+      [
+        { name: 'echo', args: { text: 'hi' } },
+        { name: 'add_step', args: { step: 'verify' } },
+      ],
+      'goal',
+    );
+
+    expect(reanchorMock).toHaveBeenCalledTimes(1);
+    expect(issueMock).toHaveBeenCalledTimes(2);
+    expect(reanchorMock.mock.invocationCallOrder[0]).toBeLessThan(
+      issueMock.mock.invocationCallOrder[1],
+    );
+  });
+
+  it('Phase 4 C5c: trueReanchor=true skips re-mint and reuses the same token', async () => {
+    const client = makeClient();
+    const s = new ArmorIQSession(client, { trueReanchor: true, defaultMcpName: 'TestMcp' });
+
+    const reanchorMock = jest.fn().mockResolvedValue({ trustId: 'tr_chain_1', delta: {} });
+    const initialToken = tokenWithPolicy();
+    const issueMock = jest
+      .fn()
+      // Only used for the first plan (no existing token yet)
+      .mockResolvedValueOnce(initialToken);
+    (client as any).reanchor = reanchorMock;
+    (client as any).getIntentToken = issueMock;
+    (client as any).capturePlan = (_llm: string, _goal: string, plan: any) => plan;
+
+    // First plan: no existing token, falls through to mint
+    const t1 = await s.startPlan([{ name: 'echo', args: { text: 'hi' } }], 'goal');
+    expect(t1).toBe(initialToken);
+    expect(reanchorMock).not.toHaveBeenCalled();
+    expect(issueMock).toHaveBeenCalledTimes(1);
+
+    // Second plan: existing token + trueReanchor → record delta and REUSE
+    const t2 = await s.startPlan(
+      [
+        { name: 'echo', args: { text: 'hi' } },
+        { name: 'add_step', args: { step: 'verify' } },
+      ],
+      'goal',
+    );
+
+    expect(reanchorMock).toHaveBeenCalledTimes(1);
+    // CRITICAL: getIntentToken was NOT called the second time
+    expect(issueMock).toHaveBeenCalledTimes(1);
+    // Same JWT object reference returned
+    expect(t2).toBe(initialToken);
+  });
+
+  it('Phase 4 C5c: trueReanchor reanchor failure falls back to legacy re-mint', async () => {
+    const client = makeClient();
+    const s = new ArmorIQSession(client, { trueReanchor: true, defaultMcpName: 'TestMcp' });
+    const reanchorMock = jest.fn().mockRejectedValue(new Error('chain endpoint down'));
+    const issueMock = jest
+      .fn()
+      .mockResolvedValueOnce(tokenWithPolicy())
+      .mockResolvedValueOnce(tokenWithPolicy());
+    (client as any).reanchor = reanchorMock;
+    (client as any).getIntentToken = issueMock;
+    (client as any).capturePlan = (_llm: string, _goal: string, plan: any) => plan;
+
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    await s.startPlan([{ name: 'echo' }], 'goal');
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }], 'goal');
+
+    // trueReanchor tries first (fails), then legacy auto-reanchor path
+    // tries again (also fails) — both call reanchor, then re-mint.
+    // What matters for this test: re-mint DID happen on fallback.
+    expect(reanchorMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(issueMock).toHaveBeenCalledTimes(2); // fallback re-mint occurred
+    warn.mockRestore();
+  });
+
+  it('Phase 4 A6: deferred granularity coalesces 3 plan growths into 1 reanchor at flush', async () => {
+    const client = makeClient();
+    const s = new ArmorIQSession(client, {
+      trueReanchor: true,
+      reanchorGranularity: 'deferred',
+      defaultMcpName: 'TestMcp',
+    });
+
+    const reanchorMock = jest.fn().mockResolvedValue({ trustId: 'tr_flush_1', delta: {} });
+    const initialToken = tokenWithPolicy();
+    const issueMock = jest.fn().mockResolvedValueOnce(initialToken);
+    (client as any).reanchor = reanchorMock;
+    (client as any).getIntentToken = issueMock;
+    (client as any).capturePlan = (_llm: string, _goal: string, plan: any) => plan;
+
+    // First plan — initial mint
+    await s.startPlan([{ name: 'echo' }], 'goal');
+    expect(reanchorMock).not.toHaveBeenCalled();
+    expect(issueMock).toHaveBeenCalledTimes(1);
+
+    // Three growths — each should DEFER, not call reanchor
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }], 'goal');
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }, { name: 'verify' }], 'goal');
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }, { name: 'verify' }, { name: 'commit' }], 'goal');
+    expect(reanchorMock).not.toHaveBeenCalled();
+
+    // Flush — should fire ONE reanchor with the latest plan
+    const result = await s.flushReanchor();
+    expect(result.fired).toBe(true);
+    expect(reanchorMock).toHaveBeenCalledTimes(1);
+    // The plan passed to reanchor should be the LATEST cumulative plan
+    const passedPlan = reanchorMock.mock.calls[0][1];
+    expect(Array.isArray(passedPlan?.steps)).toBe(true);
+    expect(passedPlan.steps.length).toBe(4);
+
+    // Second flush is a no-op (queue already drained)
+    const result2 = await s.flushReanchor();
+    expect(result2.fired).toBe(false);
+    expect(reanchorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Phase 4 A6: eager (default) granularity fires reanchor on every growth', async () => {
+    const client = makeClient();
+    // No reanchorGranularity option → defaults to 'eager'
+    const s = new ArmorIQSession(client, {
+      trueReanchor: true,
+      defaultMcpName: 'TestMcp',
+    });
+
+    const reanchorMock = jest.fn().mockResolvedValue({ trustId: 'tr_eager', delta: {} });
+    const issueMock = jest.fn().mockResolvedValueOnce(tokenWithPolicy());
+    (client as any).reanchor = reanchorMock;
+    (client as any).getIntentToken = issueMock;
+    (client as any).capturePlan = (_llm: string, _goal: string, plan: any) => plan;
+
+    await s.startPlan([{ name: 'echo' }], 'goal'); // initial mint
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }], 'goal');
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }, { name: 'verify' }], 'goal');
+
+    expect(reanchorMock).toHaveBeenCalledTimes(2); // one per growth
+    // flushReanchor in eager mode is a no-op
+    const r = await s.flushReanchor();
+    expect(r.fired).toBe(false);
+  });
+
+  it('Phase 4 A6: deferred + autoReanchor (legacy v2) still re-mints per growth, defers ONLY the delta', async () => {
+    const client = makeClient();
+    const s = new ArmorIQSession(client, {
+      // autoReanchor flag removed — always true; trueReanchor opt-in stays.
+      trueReanchor: false,
+      reanchorGranularity: 'deferred',
+      defaultMcpName: 'TestMcp',
+    });
+
+    const reanchorMock = jest.fn().mockResolvedValue({ trustId: 'tr_v2', delta: {} });
+    const issueMock = jest
+      .fn()
+      .mockResolvedValueOnce(tokenWithPolicy())
+      .mockResolvedValueOnce(tokenWithPolicy())
+      .mockResolvedValueOnce(tokenWithPolicy());
+    (client as any).reanchor = reanchorMock;
+    (client as any).getIntentToken = issueMock;
+    (client as any).capturePlan = (_llm: string, _goal: string, plan: any) => plan;
+
+    await s.startPlan([{ name: 'echo' }], 'goal'); // initial mint
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }], 'goal'); // re-mint, defer delta
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }, { name: 'verify' }], 'goal'); // re-mint, overwrite pending
+
+    // re-mints happened (legacy v2 needs fresh step_proofs each time)
+    expect(issueMock).toHaveBeenCalledTimes(3);
+    // delta NOT yet fired
+    expect(reanchorMock).not.toHaveBeenCalled();
+
+    await s.flushReanchor();
+    expect(reanchorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues to mint a new token even if reanchor delta record fails', async () => {
+    const client = makeClient();
+    const s = new ArmorIQSession(client, { trueReanchor: false, defaultMcpName: 'TestMcp' });
+
+    const reanchorMock = jest.fn().mockRejectedValue(new Error('iap unreachable'));
+    const issueMock = jest
+      .fn()
+      .mockResolvedValueOnce(tokenWithPolicy())
+      .mockResolvedValueOnce(tokenWithPolicy());
+    (client as any).reanchor = reanchorMock;
+    (client as any).getIntentToken = issueMock;
+    (client as any).capturePlan = (_llm: string, _goal: string, plan: any) => plan;
+
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    await s.startPlan([{ name: 'echo' }], 'goal');
+    await s.startPlan([{ name: 'echo' }, { name: 'add_step' }], 'goal');
+
+    expect(reanchorMock).toHaveBeenCalledTimes(1);
+    expect(issueMock).toHaveBeenCalledTimes(2); // re-mint still happened
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Remove `ARMORIQ_TRUE_REANCHOR` env flag from [session.ts](src/session.ts) and [integrations/google_adk.ts](src/integrations/google_adk.ts). Hardcode `trueReanchor` default-on.
- Constructor option `trueReanchor: false` preserved as the explicit opt-out for callers that want legacy v2 (record delta + re-mint) behavior.
- Two legacy-v2 tests now pass `trueReanchor: false` explicitly.

Closes work on [armoriq-sdk-customer-ts#56](https://github.com/armoriq/armoriq-sdk-customer-ts/issues/56). Issue stays open until reviewer marks done.

## Test plan
- [x] `npx jest tests/session.test.ts` — 16/16 pass
- [x] `npx jest` — 64/64 active tests pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)