### PR TITLE
chore: bump version to 0.3.3 (@armoriq/sdk-dev)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@armoriq/sdk-dev",
-      "version": "0.3.0",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bumps `@armoriq/sdk-dev` to **0.3.3**. Tarball already **published to npm** (registry record exists at https://www.npmjs.com/package/@armoriq/sdk-dev/v/0.3.3). This PR brings the in-repo version field in line.

## What's in 0.3.3 (commits since 0.3.2)

- feat(session): true-reanchor default + remove `ARMORIQ_TRUE_REANCHOR` env (#57)
- fix(google_adk): restore `AGENT_ID` env fallback + bootstrap respects `explicitAgentName` (Copilot review on #57)
- fix: resolve cross-agent policy attribution in ADK integration (#199)

## Test plan
- [x] `npm test` — 64/64 jest pass
- [x] `npm run build` — clean tsc
- [x] `npm publish --dry-run` — 71 files, 84.2 kB
- [x] `npm publish` — registry confirmed `+ @armoriq/sdk-dev@0.3.3`
- [x] Tag `v0.3.3` pushed to remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)