### PR TITLE
fix(dev): set baked ARMORIQ_ENV to 'staging' (one-line — restores documented branch convention)

### DIFF
--- a/src/_build_env.ts
+++ b/src/_build_env.ts
@@ -17,7 +17,7 @@
 
 export type EnvName = 'production' | 'staging' | 'local';
 
-export const ARMORIQ_ENV: EnvName = 'production';
+export const ARMORIQ_ENV: EnvName = 'staging';
 
 // Endpoint table — keep in sync with GCP Cloud Run domain mappings.
 //   prod:


### PR DESCRIPTION
## TL;DR

One-line fix: \`src/_build_env.ts\` had \`ARMORIQ_ENV = 'production'\` on the dev branch. Should be \`'staging'\` per the file's own documentation. **This is what caused the ArmorCodex demo blocker today.**

## The bug

The dev branch's \`_build_env.ts\` baked-in constant didn't match what the file itself documents:

```ts
// File's own header comment:
//   main branch  →  ARMORIQ_ENV = "production"  (prod URLs; published as stable)
//   dev  branch  →  ARMORIQ_ENV = "staging"     (staging URLs; published as -dev)

// Actual constant on dev branch (before this PR):
export const ARMORIQ_ENV: EnvName = 'production';   // ← wrong
```

So every \`@armoriq/sdk-dev@*\` published from dev shipped with production endpoints baked in.

## How this surfaced in the demo

1. \`curl install_armorcodex.sh | bash\` pulled \`@armoriq/sdk-dev@latest\` (because the live armoriq.ai installer is currently dev-flavored — armorIQ-landing#46 merged + #48 not yet merged)
2. \`armoriq login\` from the dev SDK called \`POST https://api.armoriq.ai/auth/device/code\` (prod) because \`backendBase()\` resolves via \`ARMORIQ_ENV\`, which was baked as \`'production'\`
3. Prod returned its device-code verification URL: \`https://platform.armoriq.ai/auth/device?...\`
4. User completed device-code flow on prod → got a **prod** API key
5. ArmorCodex's runtime hooks (also using sdk-dev → also baked as production-actually) sent the prod key to... ah wait actually they were configured to staging — see below

Real chain in the user's terminal log earlier today:
- Device-code login redirected to \`platform.armoriq.ai\` ❌ (proves ARMORIQ_ENV was 'production' at runtime)
- ArmorCodex \`/iap/sdk/enforce\` returned 401 "Invalid or expired API key" against \`staging-api.armoriq.ai\` (because hooks pointed at staging via different env var override, but the login flow had used prod)

The mismatch made all tool calls fall back to block. Manually swapping in a dev API key restored the demo.

## The fix

```diff
-export const ARMORIQ_ENV: EnvName = 'production';
+export const ARMORIQ_ENV: EnvName = 'staging';
```

This restores the documented convention. After merge + publish:
- \`@armoriq/sdk-dev@<next>\` will have \`ARMORIQ_ENV = 'staging'\` baked in
- \`armoriq login\` from sdk-dev installs will route to \`staging-api.armoriq.ai\` → device-code redirects to \`dev.armoriq.io\` → users get a staging key matching the staging endpoints their plugin is calling
- Merging dev → main will conflict on this line (as the file's own comment says: \"that's intentional, so the release owner consciously flips the default before publishing prod\")

## Verification

Local build confirms the flip:
```
$ grep \"exports.ARMORIQ_ENV =\" dist/_build_env.js
exports.ARMORIQ_ENV = 'staging';
```

## Follow-ups (not in this PR)

1. \`src/client.ts\` lines 170 + 508 hardcode \`https://platform.armoriq.ai/dashboard/api-keys\` in error messages — should also be env-aware (\`dev.armoriq.io\` on dev SDK). Separate PR.
2. After this PR merges, publish a new \`@armoriq/sdk-dev\` version (next patch / minor) so the live armoriq.ai installer picks it up.
3. armorIQ-landing#48 is still open — once it merges, the live installer flips back to prod refs and uses \`@armoriq/sdk\` (which is correctly baked as 'production').

🤖 Generated with [Claude Code](https://claude.com/claude-code)