### PR TITLE
Rename dev CLI bin: armoriq → armoriq-dev (eliminates npm bin collision)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "armoriq": "dist/cli/index.js"
+    "armoriq-dev": "dist/cli/index.js"
   },
   "scripts": {
     "build": "tsc",

--- a/src/_build_env.ts
+++ b/src/_build_env.ts
@@ -1,13 +1,21 @@
 /**
  * Build-time environment marker (matches armoriq-sdk-customer/_build_env.py).
  *
- * This file is the ONLY difference between the `dev` and `main` branches.
- * Merging dev → main conflicts on the `ARMORIQ_ENV` constant below —
- * that's intentional, so the release owner consciously flips the default
+ * This file is one of two intentional divergence points between the
+ * `dev` and `main` branches. Merging dev → main will conflict here and
+ * in `package.json` (different `version` + `bin` name) — that's
+ * intentional, so the release owner consciously flips both defaults
  * before publishing prod.
  *
- *   main branch  →  ARMORIQ_ENV = "production"  (prod URLs; published as stable)
- *   dev  branch  →  ARMORIQ_ENV = "staging"     (staging URLs; published as -dev)
+ *   main branch  →  ARMORIQ_ENV = "production"  (prod URLs; published as @armoriq/sdk)
+ *                   package.json bin = "armoriq"
+ *   dev  branch  →  ARMORIQ_ENV = "staging"     (staging URLs; published as @armoriq/sdk-dev)
+ *                   package.json bin = "armoriq-dev"
+ *
+ * The dev branch's bin is renamed to `armoriq-dev` so it can coexist
+ * with the prod `@armoriq/sdk` on the same machine without npm-bin
+ * collisions (which would otherwise cause silent PATH shadowing — a
+ * staging-targeted plugin would mint prod-scoped credentials).
  *
  * The baked constant is the branch-baked default. Set ARMORIQ_ENV=local
  * (or staging/production) in your shell to override at runtime. Per-


### PR DESCRIPTION
## Why

The dev installer keeps hitting PATH-shadowing bugs because **three packages all ship a bin named `armoriq`**:

| Package | Where | Backend default |
|---|---|---|
| `@armoriq/sdk` | npm prod | api.armoriq.ai (baked) |
| `@armoriq/sdk-dev` | npm dev (this) | staging-api.armoriq.ai (per #61) |
| `armoriq-sdk` | pip Python (separate codebase) | api.armoriq.ai (baked) |

When a user with `@armoriq/sdk` already installed runs `install_armorclaude_dev.sh`, `npm install -g @armoriq/sdk-dev` can EEXIST or silently leave the prod symlink in place. The installer then invokes whatever `command -v armoriq` resolves to — usually the prod CLI — which ignores `ARMORIQ_BACKEND`. OAuth opens `platform.armoriq.ai`, mints a prod key against the dev plugin's staging backend → demo blocker.

We patched the installer twice (skip CLI / validate symlink target) but each patch was a workaround for the wrong layer. Production CLIs (`gh`, `stripe`, `terraform`, AWS v2) decouple CLI from language SDKs precisely so this can't happen.

## What

- **Rename `bin` in `package.json`**: `armoriq` → `armoriq-dev`
- **Bump version**: 0.3.3 → 0.3.4
- **Document the new divergence point** in `src/_build_env.ts` so the next dev → main release flip catches both `ARMORIQ_ENV` AND the bin name.

After release:
- `npm install -g @armoriq/sdk-dev@0.3.4` creates `/usr/local/bin/armoriq-dev` — entirely new symlink, no possible conflict with `armoriq` from prod.
- Installer invokes `armoriq-dev login` explicitly. No PATH games. No symlink-target validation needed.

## Follow-ups (separate PRs)

- `armorIQ-landing/install_armorclaude_dev.sh` — invoke `armoriq-dev` not `armoriq` (coming next)
- `armoriq-sdk-customer` (Python pip) — rename `console_scripts` `armoriq` → `armoriq-py` or drop the CLI from pip entirely

## Test plan

- [x] `npm run build` passes
- [x] `dist/cli/index.js` is built with correct shebang
- [ ] After publish: `npm install -g @armoriq/sdk-dev@0.3.4` on a machine with `@armoriq/sdk` already installed → both bins coexist (`armoriq` + `armoriq-dev`)
- [ ] `ARMORIQ_BACKEND=https://staging-api.armoriq.ai armoriq-dev login --product armorclaude` opens `dev.armoriq.io` (not `platform.armoriq.ai`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)