### PR TITLE
chore: bump to 0.3.5 (publishes bin rename)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
0.3.4 shipped with only the ARMORIQ_ENV='staging' fix from #61. The bin-rename from #62 merged shortly after — bumping so it can publish.

After merge: `npm publish` from dev → npm has 0.3.5 with `armoriq-dev` bin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)