### PR TITLE
fix(cli): skip re-auth on login when already logged in

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -226,6 +226,7 @@ export async function cmdLogin(args: {
   backend?: string;
   org?: string;
   product?: string;
+  force?: boolean;
 }): Promise<number> {
   const backend = (args.backend ?? process.env.ARMORIQ_BACKEND_URL ?? backendBase()).replace(
     /\/+$/,
@@ -233,6 +234,24 @@ export async function cmdLogin(args: {
   );
   const requestedOrg = (args.org ?? '').trim();
   const product = (args.product ?? process.env.ARMORIQ_PRODUCT ?? '').trim();
+
+  // Already authenticated? Skip the browser flow unless re-auth is forced or
+  // the user is switching org. Re-running `login` otherwise just re-opens the
+  // browser for no reason.
+  if (!args.force && !requestedOrg) {
+    const existing = loadCredentials();
+    if (existing) {
+      out('');
+      out(
+        `  ${CHECK} Already logged in as \x1b[1m${existing.email || 'unknown'}\x1b[0m (org: ${existing.orgId || 'unknown'})`,
+      );
+      out(
+        '  \x1b[2mRun \x1b[0m\x1b[1marmoriq login --force\x1b[0m\x1b[2m to re-authenticate, or \x1b[0m\x1b[1marmoriq logout\x1b[0m\x1b[2m first.\x1b[0m',
+      );
+      out('');
+      return 0;
+    }
+  }
 
   out('');
   out('  \x1b[1m\x1b[36m┃ ArmorIQ Login\x1b[0m');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,10 +18,11 @@ armoriq — ArmorIQ SDK CLI
 Usage: armoriq <command> [options]
 
 Commands:
-  login [--org <name>] [--product <name>]
-                             OAuth device-code login flow. --product
-                             (armorclaude|armorcodex|armorcopilot|...) shows
-                             a product chip on the success page.
+  login [--org <name>] [--product <name>] [--force]
+                             OAuth device-code login flow. Skips re-auth if
+                             already logged in (use --force to override).
+                             --product (armorclaude|armorcodex|armorcopilot|...)
+                             shows a product chip on the success page.
   logout                     Remove cached credentials
   whoami                     Show the currently logged-in account
 
@@ -69,7 +70,8 @@ async function run(argv: Argv): Promise<number> {
       const org = parseFlag(rest, 'org') as string | undefined;
       const backend = parseFlag(rest, 'backend') as string | undefined;
       const product = parseFlag(rest, 'product') as string | undefined;
-      return cmdLogin({ org, backend, product });
+      const force = parseFlag(rest, 'force', false) === true;
+      return cmdLogin({ org, backend, product, force });
     }
     case 'logout': {
       const { cmdLogout } = await import('./commands/auth.js');


### PR DESCRIPTION
## Problem

`armoriq login` always launched the browser device-code flow — even when valid credentials were already cached at `~/.armoriq/credentials.json`. Re-running `login` (or being prompted to log in again) re-opened the browser for no reason, which made the install/login loop feel broken.

## Fix

`cmdLogin` now checks `loadCredentials()` up front. If already authenticated, it short-circuits:

```
  ✔ Already logged in as you@example.com (org: ...)
  Run armoriq login --force to re-authenticate, or armoriq logout first.
```

Escape hatches preserved:
- `--force` — re-run the full device-code flow even when logged in.
- `--org <name>` — still proceeds (org switch needs re-auth / key rotation).

## Changes
- `src/cli/commands/auth.ts` — `force?` param + early already-authenticated guard.
- `src/cli/index.ts` — parse `--force`, pass to `cmdLogin`, document in `--help`.

## Verification
- `npm run build` — clean
- `npm test` — 64 passed, 4 skipped
- Manual: `login` (creds present) → short-circuits; `login --force` → launches browser flow; `help` shows `--force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)