### PR TITLE
fix(cli): skip re-auth on login when already logged in (publish 0.3.8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@armoriq/sdk",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -226,6 +226,7 @@ export async function cmdLogin(args: {
   backend?: string;
   org?: string;
   product?: string;
+  force?: boolean;
 }): Promise<number> {
   const backend = (args.backend ?? process.env.ARMORIQ_BACKEND_URL ?? backendBase()).replace(
     /\/+$/,
@@ -233,6 +234,24 @@ export async function cmdLogin(args: {
   );
   const requestedOrg = (args.org ?? '').trim();
   const product = (args.product ?? process.env.ARMORIQ_PRODUCT ?? '').trim();
+
+  // Already authenticated? Skip the browser flow unless re-auth is forced or
+  // the user is switching org. Re-running `login` otherwise just re-opens the
+  // browser for no reason.
+  if (!args.force && !requestedOrg) {
+    const existing = loadCredentials();
+    if (existing) {
+      out('');
+      out(
+        `  ${CHECK} Already logged in as \x1b[1m${existing.email || 'unknown'}\x1b[0m (org: ${existing.orgId || 'unknown'})`,
+      );
+      out(
+        '  \x1b[2mRun \x1b[0m\x1b[1marmoriq login --force\x1b[0m\x1b[2m to re-authenticate, or \x1b[0m\x1b[1marmoriq logout\x1b[0m\x1b[2m first.\x1b[0m',
+      );
+      out('');
+      return 0;
+    }
+  }
 
   out('');
   out('  \x1b[1m\x1b[36m┃ ArmorIQ Login\x1b[0m');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,10 +18,11 @@ armoriq — ArmorIQ SDK CLI
 Usage: armoriq <command> [options]
 
 Commands:
-  login [--org <name>] [--product <name>]
-                             OAuth device-code login flow. --product
-                             (armorclaude|armorcodex|armorcopilot|...) shows
-                             a product chip on the success page.
+  login [--org <name>] [--product <name>] [--force]
+                             OAuth device-code login flow. Skips re-auth if
+                             already logged in (use --force to override).
+                             --product (armorclaude|armorcodex|armorcopilot|...)
+                             shows a product chip on the success page.
   logout                     Remove cached credentials
   whoami                     Show the currently logged-in account
 
@@ -69,7 +70,8 @@ async function run(argv: Argv): Promise<number> {
       const org = parseFlag(rest, 'org') as string | undefined;
       const backend = parseFlag(rest, 'backend') as string | undefined;
       const product = parseFlag(rest, 'product') as string | undefined;
-      return cmdLogin({ org, backend, product });
+      const force = parseFlag(rest, 'force', false) === true;
+      return cmdLogin({ org, backend, product, force });
     }
     case 'logout': {
       const { cmdLogout } = await import('./commands/auth.js');


### PR DESCRIPTION
Same fix as #68 (→ dev), applied to **main** for a prod publish.

## Problem
`armoriq login` always launched the browser device-flow even with valid cached credentials — re-running it just re-opened the browser.

## Fix
`cmdLogin` checks `loadCredentials()` up front and short-circuits with "Already logged in as <email>", unless `--force` is passed or `--org` switches orgs.

## Publish identity preserved
`@armoriq/sdk` · bin `armoriq` · `ARMORIQ_ENV=production` · version **0.3.8** (prev published 0.3.7).

## Verification
- `npm run build` clean · `npm test` 64 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)