### PR TITLE
chore: bump to 0.3.8 (published)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@armoriq/sdk-dev",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@armoriq/sdk-dev",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ArmorIQ SDK - Build secure AI agents with cryptographic intent verification.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps version + lockfile after `@armoriq/sdk-dev@0.3.8` was published to npm.